### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
+      - name: Remove dev-only path repository
+        # composer.json declares a `path` repository pointing at ../ai for
+        # the symlinked dev-app workflow. CI has no sibling checkout, so
+        # strip it before `composer install` and let Composer resolve
+        # artisanpack-ui/ai from Packagist via the ^1.0.0-alpha.1 constraint.
+        run: |
+          jq 'del(.repositories, ._comments)' composer.json > composer.json.tmp
+          mv composer.json.tmp composer.json
+
       - name: Get Composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -39,11 +48,14 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+        # Use `update` (not `install`) because we just stripped the path
+        # repository from composer.json — the lockfile is now out of sync
+        # with the effective repository set.
+        run: composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Run PHP-CS-Fixer
         run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
@@ -60,12 +72,10 @@ jobs:
       fail-fast: true
       matrix:
         laravel: ['12', '13']
-        php: ['8.2', '8.3', '8.4']
+        # PHP 8.3+ only — bumped from 8.2 in v1.1 because artisanpack-ui/ai
+        # pulls laravel/ai (^0.8), which requires PHP 8.3.
+        php: ['8.3', '8.4']
         livewire: ['3.6', '4.0']
-        exclude:
-          # Laravel 13 requires PHP 8.3+
-          - laravel: '13'
-            php: '8.2'
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -90,11 +100,20 @@ jobs:
           key: ${{ runner.os }}-php${{ matrix.php }}-laravel${{ matrix.laravel }}-lw${{ matrix.livewire }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-php${{ matrix.php }}-laravel${{ matrix.laravel }}-lw${{ matrix.livewire }}-composer-
 
+      - name: Remove dev-only path repository
+        # composer.json declares a `path` repository pointing at ../ai for
+        # the symlinked dev-app workflow. CI has no sibling checkout, so
+        # strip it before `composer update` and let Composer resolve
+        # artisanpack-ui/ai from Packagist via the ^1.0.0-alpha.1 constraint.
+        run: |
+          jq 'del(.repositories, ._comments)' composer.json > composer.json.tmp
+          mv composer.json.tmp composer.json
+
       - name: Align composer platform PHP with the matrix
-        # The repo's composer.json pins config.platform.php to 8.2 so local
-        # composer.lock stays installable on the lowest supported PHP. In CI we
-        # need composer to resolve against the matrix PHP so the Laravel 13 leg
-        # (PHP 8.3+) can install.
+        # The repo's composer.json pins config.platform.php to 8.3 so local
+        # composer.lock stays installable on the lowest supported PHP. In CI
+        # we align it to the matrix PHP so the Laravel 12 / PHP 8.4 leg (etc.)
+        # resolves against its own target.
         run: composer config platform.php ${{ matrix.php }}
 
       - name: Remove lint-only dev dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,14 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
+      - name: Remove dev-only path repository
+        # composer.json declares a `path` repository pointing at ../ai for
+        # the symlinked dev-app workflow. CI has no sibling checkout, so
+        # strip it and let Composer resolve artisanpack-ui/ai from Packagist.
+        run: |
+          jq 'del(.repositories, ._comments)' composer.json > composer.json.tmp
+          mv composer.json.tmp composer.json
+
       - name: Get Composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -29,11 +37,14 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        # Use `update` (not `install`) because we just stripped the path
+        # repository from composer.json — the lockfile is now out of sync
+        # with the effective repository set.
+        run: composer update --no-interaction --prefer-dist
 
       - name: Run tests
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Three AI-assisted features registered via `artisanpack-ui/ai`:
+  - `security.threat_triage` — `ThreatTriageAgent` + `ThreatTriagePanel` Livewire component (default model `claude-sonnet-4-6`). Plain-language severity + recommended actions for a `SecurityEvent`. Closes #20.
+  - `security.anomaly_summary` — `AnomalySummaryAgent` + `AnomalySummaryPanel` Livewire component (default model `claude-haiku-4-5-20251001`). Periodic digest of unusual events over a configurable window. Closes #21.
+  - `security.incident_response` — `IncidentResponseAgent` + `IncidentResponsePanel` Livewire component (default model `claude-opus-4-7`). Advisory-only next-step suggestions for open incidents. Closes #22.
+- Service provider now exposes an `aiFeatures()` method so the three features are auto-discovered by `artisanpack-ui/ai`'s boot pass.
+- README "AI features" section documenting the three surfaces, and shipped Blade views under `resources/views/livewire/{threat-triage,anomaly-summary,incident-response}-panel.blade.php`.
+
+### Changed
+
+- Minimum PHP requirement bumped from 8.2 to 8.3 to align with `artisanpack-ui/ai`'s transitive `laravel/ai` dependency.
+- `composer.json` now requires `artisanpack-ui/ai ^1.0.0-alpha.1` and declares a development-only `path` repository against `../ai` (CI strips this before release, matching the pattern used by `artisanpack-ui/visual-editor`).
+
 ## [1.0.1] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-07
+
 ### Added
 
 - Three AI-assisted features registered via `artisanpack-ui/ai`:
-  - `security.threat_triage` — `ThreatTriageAgent` + `ThreatTriagePanel` Livewire component (default model `claude-sonnet-4-6`). Plain-language severity + recommended actions for a `SecurityEvent`. Closes #20.
-  - `security.anomaly_summary` — `AnomalySummaryAgent` + `AnomalySummaryPanel` Livewire component (default model `claude-haiku-4-5-20251001`). Periodic digest of unusual events over a configurable window. Closes #21.
+  - `security.threat_triage` — `ThreatTriageAgent` + `ThreatTriagePanel` Livewire component (default model `claude-sonnet-4-6`). Plain-language severity and recommended actions for a `SecurityEvent`. Closes #20.
+  - `security.anomaly_summary` — `AnomalySummaryAgent` + `AnomalySummaryPanel` Livewire component (default model `claude-haiku-4-5-20251001`). Periodic digest of unusual events over a configurable window (1–720 hours). Closes #21.
   - `security.incident_response` — `IncidentResponseAgent` + `IncidentResponsePanel` Livewire component (default model `claude-opus-4-7`). Advisory-only next-step suggestions for open incidents. Closes #22.
-- Service provider now exposes an `aiFeatures()` method so the three features are auto-discovered by `artisanpack-ui/ai`'s boot pass.
-- README "AI features" section documenting the three surfaces, and shipped Blade views under `resources/views/livewire/{threat-triage,anomaly-summary,incident-response}-panel.blade.php`.
+- Service provider now exposes an `aiFeatures()` method so the three features are auto-discovered by `artisanpack-ui/ai`'s boot pass — no manual registration required by the host app.
+- `CallsLaravelAi` trait wires each agent into `laravel/ai`'s `Promptable` + structured-output pipeline, invalidates cached provider instances so per-tenant credential injection actually lands, and unwraps single-key envelopes some models add around structured tool call arguments.
+- Layered prompt overrides now flow through: the resolved `instructions()` string (settings-store override → `artisanpack.ai.features.{key}.instructions` config → class default) is threaded through to `laravel/ai` on every run.
+- Three Blade views shipped under `resources/views/livewire/{threat-triage,anomaly-summary,incident-response}-panel.blade.php`, registered as Livewire components under the namespaced tags `security-analytics.{name}-panel`. Overridable via the standard `resources/views/vendor/security-analytics/livewire/*.blade.php` shadow.
+- New `docs/usage/ai-features.md` documenting the three AI surfaces, override points, and defaults.
 
 ### Changed
 
 - Minimum PHP requirement bumped from 8.2 to 8.3 to align with `artisanpack-ui/ai`'s transitive `laravel/ai` dependency.
-- `composer.json` now requires `artisanpack-ui/ai ^1.0.0-alpha.1` and declares a development-only `path` repository against `../ai` (CI strips this before release, matching the pattern used by `artisanpack-ui/visual-editor`).
+- `composer.json` now requires `artisanpack-ui/ai ^1.0.0-alpha.1` and declares a development-only `path` repository against `../ai` for the symlinked dev-app workflow (CI strips this before install so Composer resolves from Packagist, matching the pattern used by `artisanpack-ui/visual-editor`).
+- CI test matrix drops PHP 8.2 rows; retains PHP 8.3 / 8.4 × Laravel 12 / 13 × Livewire 3.6 / 4.0.
+
+### Security
+
+- Livewire panel target IDs (`$eventId`, `$incidentId` on `ThreatTriagePanel` and `IncidentResponsePanel`) are now marked `#[Locked]` so a user with the coarse `view-security-events` capability cannot rewire the target via the wire protocol to trigger an agent on records they weren't meant to see.
+- `CallsLaravelAi::configureProvider()` invalidates `laravel/ai`'s `MultipleInstanceManager` cache after mutating credentials so a second agent's key actually lands. Without this, the first key seen by the process was silently reused for every subsequent call — a cross-tenant credential leak in multi-tenant deployments.
+- The `Throwable` catch on all three Livewire panels now logs the raw exception server-side and surfaces a generic "Check the server logs for details" message; Guzzle/Anthropic exception messages could otherwise leak the upstream URL or, under some debug configs, API-key headers into the browser DOM.
+- `ThreatTriageAgent::fetchRelated()` returns `[]` when the event has no correlation keys (`fingerprint`, `ip_address`, `user_id` all null) instead of running an empty closure-`where` that would surface up to 10 arbitrary recent events (including their PII) into the LLM prompt.
+
+### Fixed
+
+- Cache fingerprints now hash observable content instead of thin proxies: `IncidentResponseAgent` hashes the timeline contents (not just `count($timeline)`) so same-length edits / bulk updates invalidate the cache; `AnomalySummaryAgent` hashes per-anomaly (id, severity, detector) tuples so reclassification invalidates the cached digest.
+- `hash('sha256', json_encode(...))` calls in all three cache fingerprints now use `JSON_INVALID_UTF8_SUBSTITUTE` and gracefully handle a `false` return, so invalid UTF-8 in user-controlled fields (`SecurityEvent::details`, url, fingerprint) no longer crash the base pipeline with a `TypeError` before `execute()` runs.
+- `AnomalySummaryAgent::buildStatistics()` aggregates severity and detector counts entirely in the database via `selectRaw` + `groupBy` — the previous `->get()->groupBy(...)` hydrated every row into memory just to bucket-count it, and was unbounded for busy tenants.
+- `AnomalySummaryAgent::payload()` gained an `is_array` guard on `$input['anomalies']` / `$input['statistics']` mirroring `IncidentResponseAgent`; callers passing a Collection or non-array now get the documented `InvalidArgumentException` instead of a raw `TypeError` from `array_values`.
+- `AnomalySummaryAgent::$stream` set to `false` — the previous `true` was documented as "streaming on by default" but `execute()` used the non-streaming path, so any `streamTo($cb)` callback silently dropped every chunk.
+- `unwrapStructured()` early-return guard removed; `array_intersect` alone correctly handles Opus's double-wrap under the schema's own parameter name.
+- `outputSchema()` on each agent is now derived from `schema()` via `ObjectSchema` on the trait, killing the double-source-of-truth between the array-literal and fluent forms.
+- `aiFeatures()` labels/descriptions and all `abort(403)` messages wrapped in `__()` for i18n. Panel `render()` methods gained explicit `: View` return types.
 
 ## [1.0.1] - 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,42 @@ This package is part of the **ArtisanPack UI Security 2.0** split — the analyt
 - **Events** (3) — `SecurityEventOccurred`, `AnomalyDetected`, `SuspiciousActivityDetected` — subscribe to integrate with downstream systems.
 - `SecurityAnalytics` Facade + `security_analytics()` helper.
 
+## AI features
+
+The package registers three AI-assisted surfaces via `artisanpack-ui/ai` when installed. Each is a plain Livewire component wired to an agent that extends `ArtisanPackUI\Ai\Agents\ArtisanPackAgent`, so it inherits the shared feature toggle, credential resolver, cache pipeline, and usage tracking.
+
+| Feature key | Agent | Livewire component | Default model | Purpose |
+|---|---|---|---|---|
+| `security.threat_triage` | `ThreatTriageAgent` | `ThreatTriagePanel` | `claude-sonnet-4-6` | Plain-language severity and recommended actions for a single `SecurityEvent`. |
+| `security.anomaly_summary` | `AnomalySummaryAgent` | `AnomalySummaryPanel` | `claude-haiku-4-5-20251001` | Periodic digest of unusual events over a configurable window (default 24h). |
+| `security.incident_response` | `IncidentResponseAgent` | `IncidentResponsePanel` | `claude-opus-4-7` | Suggested next steps for an open `SecurityIncident`. Advisory only — never triggers actions. |
+
+Features are discovered automatically from the service provider's `aiFeatures()` method by the `artisanpack-ui/ai` boot pass — no manual registration required. Each feature is togglable at runtime via the shared feature registry, and each Livewire panel renders a disabled state when the feature is off or when credentials cannot be resolved (no LLM calls happen in either case).
+
+Render a panel inline anywhere you have an event or incident:
+
+```blade
+{{-- On the security-event detail surface --}}
+<livewire:threat-triage-panel :event-id="$event->id" />
+
+{{-- Somewhere on the dashboard --}}
+<livewire:anomaly-summary-panel />
+
+{{-- On the incident detail surface --}}
+<livewire:incident-response-panel :incident-id="$incident->id" />
+```
+
+The three agents are also invocable directly from PHP:
+
+```php
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\ThreatTriageAgent;
+
+$triage = ThreatTriageAgent::for( $securityEvent )->run();
+// [ 'severity' => 'high', 'summary' => '…', 'recommended_actions' => [ … ], 'related_events' => [ … ] ]
+```
+
+Override the shipped Blade views by shadowing them under `resources/views/vendor/security-analytics/livewire/{threat-triage-panel,anomaly-summary-panel,incident-response-panel}.blade.php`.
+
 ## Installation
 
 ```bash
@@ -79,10 +115,10 @@ The dashboard views ship as plain HTML + Tailwind by design — the package does
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 10 / 11 / 12
-- Laravel 13 (requires PHP 8.3+)
-- `livewire/livewire` ^3.6 or ^4.0 (only required for the dashboard UI; the rest of the package works without Livewire)
+- PHP 8.3+
+- Laravel 10 / 11 / 12 / 13
+- `artisanpack-ui/ai` ^1.0.0-alpha.1 — foundation for the three AI features (see [AI features](#ai-features))
+- `livewire/livewire` ^3.6 or ^4.0 (only required for the dashboard UI + AI panels; the rest of the package works without Livewire)
 
 ## Sibling packages
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Render a panel inline anywhere you have an event or incident:
 
 ```blade
 {{-- On the security-event detail surface --}}
-<livewire:threat-triage-panel :event-id="$event->id" />
+<livewire:security-analytics.threat-triage-panel :event-id="$event->id" />
 
 {{-- Somewhere on the dashboard --}}
-<livewire:anomaly-summary-panel />
+<livewire:security-analytics.anomaly-summary-panel />
 
 {{-- On the incident detail surface --}}
-<livewire:incident-response-panel :incident-id="$incident->id" />
+<livewire:security-analytics.incident-response-panel :incident-id="$incident->id" />
 ```
 
 The three agents are also invocable directly from PHP:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Security analytics for Laravel — security event logging, anomaly detection, threat intelligence, SIEM export (Splunk, Datadog, Elasticsearch, syslog), incident response, alerting, and dashboards.",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "keywords": [
     "laravel",
     "security",

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,22 @@
     }
   ],
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+    "artisanpack-ui/ai": "^1.0.0-alpha.1",
     "artisanpack-ui/core": "^1.0"
+  },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../ai",
+      "options": {
+        "symlink": true
+      }
+    }
+  ],
+  "_comments": {
+    "repositories": "The path repository to ../ai is a development-only convenience for the symlinked workflow used in the dev-app. On a fresh clone without the sibling ai checkout, composer install will fail to resolve artisanpack-ui/ai — that's expected for now; the package's release pipeline pulls it from Packagist via the ^1.0.0-alpha.1 constraint. CI removes this entry before installing."
   },
   "require-dev": {
     "artisanpack-ui/code-style": "^1.1",
@@ -67,7 +80,7 @@
       "dealerdirect/phpcodesniffer-composer-installer": true
     },
     "platform": {
-      "php": "8.2"
+      "php": "8.3"
     }
   },
   "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,95 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a080030f5c5055b8dda2794455e9f1e",
+    "content-hash": "fa70694518879d12c939f8cbccdbcde3",
     "packages": [
+        {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0-alpha.1",
+            "dist": {
+                "type": "path",
+                "url": "../ai",
+                "reference": "d4223331b41b46e5258258ee561299ee82663325"
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ],
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "lint": [
+                    "./vendor/bin/php-cs-fixer fix --dry-run --diff",
+                    "./vendor/bin/phpcs"
+                ],
+                "fix": [
+                    "./vendor/bin/php-cs-fixer fix"
+                ],
+                "cs": [
+                    "./vendor/bin/phpcs"
+                ],
+                "cs:fix": [
+                    "./vendor/bin/phpcbf"
+                ],
+                "test": [
+                    "./vendor/bin/pest"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "transport-options": {
+                "symlink": true,
+                "relative": true
+            }
+        },
         {
             "name": "artisanpack-ui/core",
             "version": "1.2.0",
@@ -74,6 +161,157 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.388.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "6dd9a0674641ef7d302a50cc8f275eb443182dc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6dd9a0674641ef7d302a50cc8f275eb443182dc9",
+                "reference": "6dd9a0674641ef7d302a50cc8f275eb443182dc9",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.0"
+            },
+            "time": "2026-07-07T18:11:48+00:00"
         },
         {
             "name": "brick/math",
@@ -1205,6 +1443,80 @@
             "time": "2026-06-12T21:33:43+00:00"
         },
         {
+            "name": "laravel/ai",
+            "version": "v0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
+        },
+        {
             "name": "laravel/framework",
             "version": "v12.62.0",
             "source": {
@@ -2207,6 +2519,72 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -3805,6 +4183,76 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/finder",
@@ -10977,76 +11425,6 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v7.4.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-11T16:38:44+00:00"
-        },
-        {
             "name": "symfony/options-resolver",
             "version": "v7.4.8",
             "source": {
@@ -11521,11 +11899,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.3"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.3"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa70694518879d12c939f8cbccdbcde3",
+    "content-hash": "6343303c66a99f250c0bd851eac1304d",
     "packages": [
         {
             "name": "artisanpack-ui/ai",
@@ -1027,26 +1027,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.11.1",
+            "version": "7.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
+                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
-                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/bcd989ad36c92d42a3715379af91f2defee5b8dd",
+                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.11",
+                "guzzlehttp/psr7": "^2.12.3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1054,8 +1054,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -1135,7 +1135,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.13.2"
             },
             "funding": [
                 {
@@ -1151,7 +1151,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-07T22:54:06+00:00"
+            "time": "2026-07-05T19:00:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1239,16 +1239,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
@@ -1257,7 +1257,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1338,7 +1338,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -1354,7 +1354,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:30:48+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -3868,16 +3868,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -3915,7 +3915,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3935,7 +3935,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,11 +35,24 @@ The package's public API surface, organized by subsystem.
 
 All contracts are in `src/Analytics/*/Contracts/` (with two exceptions in `src/Contracts/` and `src/Authentication/Contracts/`).
 
+## AI agents *(new in 1.1)*
+
+3 agents under `src/AI/Agents/`, each extending `ArtisanPackUI\Ai\Agents\ArtisanPackAgent` and implementing `Laravel\Ai\Contracts\Agent` + `Laravel\Ai\Contracts\HasStructuredOutput`:
+
+| Class | Feature key | Livewire tag |
+|---|---|---|
+| `ThreatTriageAgent` | `security.threat_triage` | `security-analytics.threat-triage-panel` |
+| `AnomalySummaryAgent` | `security.anomaly_summary` | `security-analytics.anomaly-summary-panel` |
+| `IncidentResponseAgent` | `security.incident_response` | `security-analytics.incident-response-panel` |
+
+Shared wiring lives in the `CallsLaravelAi` trait under `src/AI/Concerns/`. Registered via `SecurityAnalyticsServiceProvider::aiFeatures()` and auto-discovered by `artisanpack-ui/ai`'s boot pass. See [AI features](usage/ai-features.md) for the full usage guide.
+
 ## Events
 
 - `SecurityEventOccurred` — fired after every `security_events` row is written
 - `AnomalyDetected` — fired for every new `Anomaly` row
 - `SuspiciousActivityDetected` — fired by the suspicious activity service
+- `Laravel\Ai\Events\AgentUsageRecorded` (via `artisanpack-ui/ai`) — fired after every AI agent run; subscribe to bill tokens back to a per-tenant budget
 
 ## Jobs
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -18,6 +18,7 @@ This package is part of the **ArtisanPack UI Security 2.0** split.
 - **Alerting** — 8 channel implementations + rule + history models
 - **Reports** — 6 report types, on-demand or scheduled
 - **Dashboard** — controller + 4 Livewire components with shipped Blade views
+- **AI features** *(new in 1.1)* — plain-language threat triage, periodic anomaly digest, advisory-only incident-response suggestions
 
 Everything pluggable can be replaced with a custom implementation by binding your class against the corresponding interface in a service provider.
 

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -6,21 +6,25 @@ title: Requirements
 
 ## PHP
 
-- PHP 8.2+
+- PHP 8.3+ (bumped from 8.2 in v1.1.0 to align with `artisanpack-ui/ai`'s transitive `laravel/ai` dependency)
 
 ## Laravel
 
-- Laravel 10 / 11 / 12
-- Laravel 13 (requires PHP 8.3+)
+- Laravel 10 / 11 / 12 / 13
 
 ## Composer dependencies (pulled in automatically)
 
 - `artisanpack-ui/core: ^1.0`
+- `artisanpack-ui/ai: ^1.0.0-alpha.1` — foundation for the three AI features (see [AI features](../usage/ai-features.md))
 
 ## Optional dependencies
 
-- **`livewire/livewire` (^3.6 \| ^4.0)** — only required for the dashboard UI. The rest of the package (logging, detection, SIEM, alerts, jobs, commands) works without Livewire installed.
+- **`livewire/livewire` (^3.6 \| ^4.0)** — required for the dashboard UI **and** the three AI trigger panels (`ThreatTriagePanel`, `AnomalySummaryPanel`, `IncidentResponsePanel`). The rest of the package (logging, detection, SIEM, alerts, jobs, commands) works without Livewire installed.
 - **`pragmarx/google2fa` (^8.0)** — only required if you wire a TwoFactor-related action into a playbook.
+
+## AI provider credentials (per-feature)
+
+The three AI features route through `laravel/ai`'s provider system via `artisanpack-ui/ai`'s credential resolver. Configure once via the AI package's env vars or admin UI; the security-analytics agents pick them up automatically. Anthropic, OpenAI, Gemini, Ollama, and the rest of the `laravel/ai` provider set are all supported — the agents' default models target Anthropic (Opus 4.7 / Sonnet 4.6 / Haiku 4.5) but can be overridden per feature via `artisanpack.ai.features.{key}.model` or the AI Settings admin surface.
 
 ## External services (per-feature)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,7 @@ Per-subsystem reference. Each topic is a self-contained surface — you can use 
 - [Alerting](usage/alerting.md) — channels, alert rules, alert history
 - [Reports](usage/reports.md) — on-demand vs scheduled, the 6 report types
 - [Dashboard](usage/dashboard.md) — Livewire UI + JSON API endpoints
+- [AI features](usage/ai-features.md) — threat triage, anomaly digest, incident-response suggestions (new in 1.1)
 - [Artisan commands](usage/artisan-commands.md) — full command reference
 
 ## Quick reference

--- a/docs/usage/ai-features.md
+++ b/docs/usage/ai-features.md
@@ -1,0 +1,177 @@
+---
+title: AI features
+---
+
+# AI features
+
+`v1.1.0` adds three AI-assisted surfaces to the package, built on top of `artisanpack-ui/ai`. Each is opt-in (togglable at runtime via the shared feature registry), advisory-only (nothing runs automatically), and short-circuits cleanly when the toggle is off or when credentials cannot be resolved — no LLM calls happen in either case.
+
+## The three features
+
+| Feature key | Agent class | Livewire component | Default model | Purpose |
+|---|---|---|---|---|
+| `security.threat_triage` | `ThreatTriageAgent` | `ThreatTriagePanel` | `claude-sonnet-4-6` | Plain-language severity + recommended actions for a single `SecurityEvent`. |
+| `security.anomaly_summary` | `AnomalySummaryAgent` | `AnomalySummaryPanel` | `claude-haiku-4-5-20251001` | Periodic digest of unusual events over a configurable window (1–720 hours). |
+| `security.incident_response` | `IncidentResponseAgent` | `IncidentResponsePanel` | `claude-opus-4-7` | Advisory-only next-step suggestions for an open incident. Never triggers actions. |
+
+All three implement `Laravel\Ai\Contracts\Agent` and `Laravel\Ai\Contracts\HasStructuredOutput`, so the response is validated JSON matching each agent's schema — no free-text parsing on your side.
+
+## Discovery
+
+The service provider exposes an `aiFeatures()` method that `artisanpack-ui/ai`'s boot pass walks looking for feature registrations:
+
+```php
+public function aiFeatures(): array
+{
+    return [
+        'security.threat_triage'     => [ 'agent' => ThreatTriageAgent::class, ... ],
+        'security.anomaly_summary'   => [ 'agent' => AnomalySummaryAgent::class, ... ],
+        'security.incident_response' => [ 'agent' => IncidentResponseAgent::class, ... ],
+    ];
+}
+```
+
+No manual registration on the host app's side. If `artisanpack-ui/ai` isn't installed the discovery pass never runs and the features stay dormant.
+
+## Livewire panels
+
+Each agent has a matching Livewire trigger panel registered under a namespaced tag. Drop them into any Blade view:
+
+```blade
+{{-- On the security-event detail surface --}}
+<livewire:security-analytics.threat-triage-panel :event-id="$event->id" />
+
+{{-- Somewhere on the dashboard --}}
+<livewire:security-analytics.anomaly-summary-panel />
+
+{{-- On the incident detail surface --}}
+<livewire:security-analytics.incident-response-panel :incident-id="$incident->id" />
+```
+
+Each panel:
+
+- Gates on the standard `view-security-events` / `view-security-dashboard` abilities
+- Marks target IDs `#[Locked]` so the client can't rewire the target via the wire protocol
+- Renders a disabled state when the feature is toggled off or credentials aren't configured (no LLM call fires)
+- Logs any provider exception server-side and shows the user a generic error message (so Guzzle stack traces don't leak API keys into the DOM)
+
+### Shipped Blade views
+
+Plain HTML + Tailwind by design — the package doesn't depend on `artisanpack-ui/livewire-ui-components`. Override the shipped views by shadowing them:
+
+```
+resources/views/vendor/security-analytics/livewire/threat-triage-panel.blade.php
+resources/views/vendor/security-analytics/livewire/anomaly-summary-panel.blade.php
+resources/views/vendor/security-analytics/livewire/incident-response-panel.blade.php
+```
+
+Laravel resolves your overrides before the package defaults.
+
+## Direct invocation
+
+The three agents are also usable from PHP (jobs, commands, controllers) without the Livewire panel:
+
+```php
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\ThreatTriageAgent;
+
+$triage = ThreatTriageAgent::for( $securityEvent )->run();
+
+// [
+//   'severity'            => 'high',
+//   'summary'             => '…',
+//   'recommended_actions' => [ [ 'step' => '…', 'urgency' => 'immediate' ], … ],
+//   'related_events'      => [ 42, 43, 44 ],
+// ]
+```
+
+Input shapes accepted:
+
+| Agent | Input |
+|---|---|
+| `ThreatTriageAgent` | `SecurityEvent` model, event id (int), or `[ 'event' => [...], 'related' => [...], 'context' => [...] ]` |
+| `AnomalySummaryAgent` | Window in hours (int), or `[ 'window_hours' => int, 'anomalies' => [...], 'statistics' => [...] ]` |
+| `IncidentResponseAgent` | `SecurityIncident` model, incident id (int), or `[ 'incident' => [...], 'timeline' => [...], 'playbooks' => [...] ]` |
+
+## Toggling features
+
+Each feature is togglable at runtime via `artisanpack-ui/ai`'s feature registry:
+
+```php
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+
+$registry = app( FeatureRegistry::class );
+
+$registry->disable( 'security.threat_triage' );
+$registry->enable( 'security.threat_triage' );
+$registry->isToggleOn( 'security.threat_triage' );
+$registry->isEnabled( 'security.threat_triage' ); // toggle + credentials
+```
+
+When disabled, `ThreatTriageAgent::for(...)->run()` throws `FeatureDisabledException`. The Livewire panels catch this and render a disabled state; direct callers can catch it themselves.
+
+## Overriding prompts and models
+
+Prompt and model overrides layer via `artisanpack.ai.features.{feature_key}`:
+
+```php
+// config/artisanpack/ai.php
+return [
+    'features' => [
+        'security.threat_triage' => [
+            'model'        => 'claude-haiku-4-5-20251001',
+            'instructions' => <<<'PROMPT'
+                Your team's custom triage prompt goes here.
+                Keep the schema fields (severity/summary/…) intact.
+                PROMPT,
+        ],
+    ],
+];
+```
+
+Precedence (top wins):
+
+1. `FeatureSettings` store (usually written by the AI Settings admin UI)
+2. `artisanpack.ai.features.{key}.instructions` / `.model` config value
+3. Class defaults on the agent
+
+Instructions are applied per-run through the `CallsLaravelAi` trait, so overrides don't require a redeploy.
+
+## Credentials
+
+Credentials resolve via `artisanpack-ui/ai`'s `CredentialResolver` chain:
+
+1. Runtime override on the agent (`->withCredentials($creds)`)
+2. `FeatureSettings` store (per-feature)
+3. Env vars (`ARTISANPACK_AI_API_KEY`, `ARTISANPACK_AI_PROVIDER`, `ARTISANPACK_AI_DEFAULT_MODEL`, …)
+
+The security-analytics agents don't hard-code Anthropic — flip `ARTISANPACK_AI_PROVIDER` to `openai` / `gemini` / `ollama` / etc. and the same agents route to that provider. Default models on each agent are Anthropic-flavored but overridable via config as above.
+
+Under Octane, RoadRunner, and queue workers, the `CallsLaravelAi::configureProvider()` step invalidates `laravel/ai`'s cached provider so a rotated key (or a per-tenant credential injection between agents) actually lands — see the `Fixed` block in [CHANGELOG.md](../../CHANGELOG.md) under 1.1.0.
+
+## Caching
+
+Each agent caches responses using a content-derived fingerprint:
+
+- `ThreatTriageAgent` — event fields + related-event window + context
+- `AnomalySummaryAgent` — window + per-anomaly (id, severity, detector) tuples
+- `IncidentResponseAgent` — incident id + severity + status + updated_at + timeline contents
+
+TTL and the cache store are the AI package's `artisanpack.ai.cache.*` settings — see `artisanpack-ui/ai`'s docs. Set `$agent->cacheable = false` (or per-feature config) to disable caching entirely.
+
+## Cost + performance
+
+- **ThreatTriageAgent** (Sonnet 4.6) — one round-trip per event; typical response ~1–3 seconds. Related-event fetch is capped at 10 rows.
+- **AnomalySummaryAgent** (Haiku 4.5) — one round-trip per window; anomaly rows capped at 50 for the LLM payload, but aggregate `total_count` / `by_severity` / `by_detector` are computed via DB `GROUP BY` so they're accurate for busy windows.
+- **IncidentResponseAgent** (Opus 4.7) — one round-trip per invocation. Deeper model tier, so ~3–8 seconds per call; use sparingly on high-volume queue paths.
+
+The `AgentUsageRecorded` event fires after every run — subscribe to it to bill tokens back to a per-tenant budget (`artisanpack-ui/ai` also ships a `BudgetSettings` service that consumes the same event).
+
+## Advisory-only
+
+None of the three agents trigger response actions. They emit structured advice; the responder decides what to run. The action-execution surface remains `Analytics\IncidentResponse\IncidentResponder` (10 pluggable actions, playbook-driven approval). See [Incident response](incident-response.md) for that surface.
+
+## Follow-ups
+
+- [Incident response](incident-response.md) — the manual + playbook-driven action surface the AI advises on
+- [Dashboard](dashboard.md) — where the AI panels typically get mounted
+- `artisanpack-ui/ai` docs — the AI Settings admin UI, credential resolver chain, feature registry, budget tracking

--- a/resources/views/livewire/anomaly-summary-panel.blade.php
+++ b/resources/views/livewire/anomaly-summary-panel.blade.php
@@ -1,0 +1,103 @@
+{{--
+    Anomaly Summary Panel.
+
+    Plain HTML + Tailwind by design. Override this view in your app
+    (resources/views/vendor/security-analytics/livewire/anomaly-summary-panel.blade.php)
+    to change the styling.
+--}}
+<div class="bg-white shadow rounded-lg p-4">
+    <div class="flex items-start justify-between gap-4 mb-3">
+        <div>
+            <h3 class="text-lg font-bold">{{ __( 'Anomaly summary' ) }}</h3>
+            <p class="text-sm text-gray-500">
+                {{ __( 'AI-generated digest of unusual security activity over the last :hours hours.', [ 'hours' => $windowHours ] ) }}
+            </p>
+        </div>
+
+        <div class="flex items-center gap-2 shrink-0">
+            <label class="text-sm text-gray-600" for="anomaly-summary-window">{{ __( 'Window (hours)' ) }}</label>
+            <input
+                type="number"
+                id="anomaly-summary-window"
+                min="1"
+                max="720"
+                wire:model="windowHours"
+                class="w-20 px-2 py-1 text-sm border border-gray-300 rounded-md"
+            />
+
+            @if ( $available )
+                <button
+                    type="button"
+                    wire:click="generate"
+                    wire:loading.attr="disabled"
+                    class="inline-flex items-center px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded-md"
+                >
+                    <span wire:loading.remove wire:target="generate">{{ __( 'Generate' ) }}</span>
+                    <span wire:loading wire:target="generate">{{ __( 'Generating…' ) }}</span>
+                </button>
+            @elseif ( ! $toggleOn )
+                <span class="inline-flex items-center px-3 py-1.5 bg-gray-100 text-gray-500 text-sm font-medium rounded-md">
+                    {{ __( 'Disabled' ) }}
+                </span>
+            @else
+                <span class="inline-flex items-center px-3 py-1.5 bg-yellow-100 text-yellow-800 text-sm font-medium rounded-md">
+                    {{ __( 'Credentials required' ) }}
+                </span>
+            @endif
+        </div>
+    </div>
+
+    @if ( $error )
+        <div class="rounded-md bg-red-50 p-3 text-sm text-red-800 mb-3">
+            {{ $error }}
+        </div>
+    @endif
+
+    @if ( $result )
+        <div class="border-t pt-3 space-y-3">
+            <h4 class="text-base font-semibold text-gray-900">{{ $result['headline'] ?? '' }}</h4>
+            <p class="text-sm text-gray-800 leading-relaxed">{{ $result['body'] ?? '' }}</p>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                @if ( ! empty( $result['top_severities'] ) )
+                    <div>
+                        <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">{{ __( 'Top severities' ) }}</div>
+                        <ul class="space-y-1 text-sm">
+                            @foreach ( $result['top_severities'] as $index => $bucket )
+                                <li wire:key="summary-severity-{{ $index }}" class="flex justify-between">
+                                    <span class="text-gray-800">{{ $bucket['severity'] ?? '' }}</span>
+                                    <span class="text-gray-500">{{ $bucket['count'] ?? 0 }}</span>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                @if ( ! empty( $result['top_detectors'] ) )
+                    <div>
+                        <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">{{ __( 'Top detectors' ) }}</div>
+                        <ul class="space-y-1 text-sm">
+                            @foreach ( $result['top_detectors'] as $index => $bucket )
+                                <li wire:key="summary-detector-{{ $index }}" class="flex justify-between">
+                                    <span class="text-gray-800">{{ $bucket['detector'] ?? '' }}</span>
+                                    <span class="text-gray-500">{{ $bucket['count'] ?? 0 }}</span>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+            </div>
+
+            @if ( ! empty( $result['recommended_followups'] ) )
+                <div>
+                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">{{ __( 'Recommended follow-ups' ) }}</div>
+                    <ul class="list-disc pl-5 space-y-1 text-sm text-gray-800">
+                        @foreach ( $result['recommended_followups'] as $index => $followup )
+                            <li wire:key="summary-followup-{{ $index }}">{{ $followup }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/incident-response-panel.blade.php
+++ b/resources/views/livewire/incident-response-panel.blade.php
@@ -1,0 +1,75 @@
+{{--
+    Incident Response Panel.
+
+    Plain HTML + Tailwind by design. Suggestion-only — this component never
+    triggers an action. Override this view in your app
+    (resources/views/vendor/security-analytics/livewire/incident-response-panel.blade.php)
+    to change the styling.
+--}}
+<div class="bg-white shadow rounded-lg p-4">
+    <div class="flex items-start justify-between mb-3">
+        <div>
+            <h3 class="text-lg font-bold">{{ __( 'Incident response suggestions' ) }}</h3>
+            <p class="text-sm text-gray-500">
+                {{ __( 'AI-suggested next steps for this incident. Advisory only — nothing runs automatically.' ) }}
+            </p>
+        </div>
+
+        @if ( $available )
+            <button
+                type="button"
+                wire:click="suggest"
+                wire:loading.attr="disabled"
+                class="inline-flex items-center px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded-md"
+            >
+                <span wire:loading.remove wire:target="suggest">{{ __( 'Suggest next steps' ) }}</span>
+                <span wire:loading wire:target="suggest">{{ __( 'Thinking…' ) }}</span>
+            </button>
+        @elseif ( ! $toggleOn )
+            <span class="inline-flex items-center px-3 py-1.5 bg-gray-100 text-gray-500 text-sm font-medium rounded-md">
+                {{ __( 'Disabled' ) }}
+            </span>
+        @else
+            <span class="inline-flex items-center px-3 py-1.5 bg-yellow-100 text-yellow-800 text-sm font-medium rounded-md">
+                {{ __( 'Credentials required' ) }}
+            </span>
+        @endif
+    </div>
+
+    @if ( $error )
+        <div class="rounded-md bg-red-50 p-3 text-sm text-red-800 mb-3">
+            {{ $error }}
+        </div>
+    @endif
+
+    @if ( $result )
+        <div class="border-t pt-3">
+            @if ( empty( $result['suggested_next_actions'] ) )
+                <p class="text-sm text-gray-500">{{ __( 'No suggestions returned.' ) }}</p>
+            @else
+                <ol class="space-y-3">
+                    @foreach ( $result['suggested_next_actions'] as $index => $action )
+                        <li wire:key="incident-suggestion-{{ $index }}" class="border rounded-md p-3">
+                            <div class="flex items-start justify-between gap-2">
+                                <span class="font-medium text-gray-900">
+                                    {{ $index + 1 }}. {{ $action['step'] ?? '' }}
+                                </span>
+                                <span
+                                    @class( [
+                                        'inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold',
+                                        'bg-green-100 text-green-800'  => 'low' === ( $action['risk'] ?? '' ),
+                                        'bg-yellow-100 text-yellow-800' => 'medium' === ( $action['risk'] ?? '' ),
+                                        'bg-red-100 text-red-800'      => 'high' === ( $action['risk'] ?? '' ),
+                                    ] )
+                                >
+                                    {{ __( 'Risk: :risk', [ 'risk' => $action['risk'] ?? 'unknown' ] ) }}
+                                </span>
+                            </div>
+                            <p class="text-sm text-gray-600 mt-1">{{ $action['rationale'] ?? '' }}</p>
+                        </li>
+                    @endforeach
+                </ol>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/threat-triage-panel.blade.php
+++ b/resources/views/livewire/threat-triage-panel.blade.php
@@ -1,0 +1,96 @@
+{{--
+    Threat Triage Panel.
+
+    Plain HTML + Tailwind by design. Override this view in your app
+    (resources/views/vendor/security-analytics/livewire/threat-triage-panel.blade.php)
+    to change the styling.
+--}}
+<div class="bg-white shadow rounded-lg p-4">
+    <div class="flex items-start justify-between mb-3">
+        <div>
+            <h3 class="text-lg font-bold">{{ __( 'Threat triage' ) }}</h3>
+            <p class="text-sm text-gray-500">
+                {{ __( 'AI-assisted severity and recommended actions for this security event.' ) }}
+            </p>
+        </div>
+
+        @if ( $available )
+            <button
+                type="button"
+                wire:click="triage"
+                wire:loading.attr="disabled"
+                class="inline-flex items-center px-3 py-1.5 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-medium rounded-md"
+            >
+                <span wire:loading.remove wire:target="triage">{{ __( 'Run triage' ) }}</span>
+                <span wire:loading wire:target="triage">{{ __( 'Analyzing…' ) }}</span>
+            </button>
+        @elseif ( ! $toggleOn )
+            <span class="inline-flex items-center px-3 py-1.5 bg-gray-100 text-gray-500 text-sm font-medium rounded-md">
+                {{ __( 'Disabled' ) }}
+            </span>
+        @else
+            <span class="inline-flex items-center px-3 py-1.5 bg-yellow-100 text-yellow-800 text-sm font-medium rounded-md">
+                {{ __( 'Credentials required' ) }}
+            </span>
+        @endif
+    </div>
+
+    @if ( $error )
+        <div class="rounded-md bg-red-50 p-3 text-sm text-red-800 mb-3">
+            {{ $error }}
+        </div>
+    @endif
+
+    @if ( $result )
+        <div class="border-t pt-3 space-y-3">
+            <div class="flex items-center gap-2">
+                <span class="text-xs uppercase tracking-wide text-gray-500">{{ __( 'Severity' ) }}</span>
+                <span
+                    @class( [
+                        'inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold',
+                        'bg-gray-100 text-gray-700'   => 'info' === ( $result['severity'] ?? 'info' ),
+                        'bg-blue-100 text-blue-800'   => 'low' === ( $result['severity'] ?? '' ),
+                        'bg-yellow-100 text-yellow-800' => 'medium' === ( $result['severity'] ?? '' ),
+                        'bg-orange-100 text-orange-800' => 'high' === ( $result['severity'] ?? '' ),
+                        'bg-red-100 text-red-800'     => 'critical' === ( $result['severity'] ?? '' ),
+                    ] )
+                >
+                    {{ $result['severity'] ?? 'info' }}
+                </span>
+            </div>
+
+            <div>
+                <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">{{ __( 'Summary' ) }}</div>
+                <p class="text-sm text-gray-800">{{ $result['summary'] ?? '' }}</p>
+            </div>
+
+            @if ( ! empty( $result['recommended_actions'] ) )
+                <div>
+                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-2">{{ __( 'Recommended actions' ) }}</div>
+                    <ol class="space-y-1">
+                        @foreach ( $result['recommended_actions'] as $index => $action )
+                            <li wire:key="triage-action-{{ $index }}" class="flex items-start gap-2 text-sm">
+                                <span class="mt-0.5 shrink-0 inline-block w-5 h-5 rounded-full bg-gray-100 text-gray-700 text-xs flex items-center justify-center">
+                                    {{ $index + 1 }}
+                                </span>
+                                <span class="flex-1">
+                                    <span class="text-gray-800">{{ $action['step'] ?? '' }}</span>
+                                    <span class="ml-2 text-xs text-gray-500">({{ $action['urgency'] ?? '' }})</span>
+                                </span>
+                            </li>
+                        @endforeach
+                    </ol>
+                </div>
+            @endif
+
+            @if ( ! empty( $result['related_events'] ) )
+                <div>
+                    <div class="text-xs uppercase tracking-wide text-gray-500 mb-1">{{ __( 'Related events' ) }}</div>
+                    <p class="text-sm text-gray-600">
+                        {{ implode( ', ', array_map( fn ( $id ) => '#' . $id, $result['related_events'] ) ) }}
+                    </p>
+                </div>
+            @endif
+        </div>
+    @endif
+</div>

--- a/src/AI/Agents/AnomalySummaryAgent.php
+++ b/src/AI/Agents/AnomalySummaryAgent.php
@@ -1,0 +1,341 @@
+<?php
+
+/**
+ * AnomalySummaryAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAnalytics\AI\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\SecurityAnalytics\Models\Anomaly;
+use InvalidArgumentException;
+
+/**
+ * Produces a periodic (daily / weekly) digest of unusual security activity.
+ *
+ * Intended for stakeholders who don't watch the SIEM in real time. Takes a
+ * window (in hours), pulls recent anomalies + aggregate statistics, and
+ * returns a structured digest: headline, plain-language body, top-severity
+ * breakdown, top detectors, and any recommended follow-ups.
+ *
+ * When {@see \ArtisanPackUI\Ai\Agents\SummarizationAgent} lands in
+ * `artisanpack-ui/ai`, this class will move to extend it and inherit the
+ * shared summary framing. Until then it extends {@see ArtisanPackAgent}
+ * directly so the digest surface is available in v1.1.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @since      1.1.0
+ */
+class AnomalySummaryAgent extends ArtisanPackAgent
+{
+    /**
+     * Feature key registered with the AI feature registry.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $featureKey = 'security.anomaly_summary';
+
+    /**
+     * Owning composer package.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $package = 'artisanpack-ui/security-analytics';
+
+    /**
+     * Default model — Haiku is fast and cheap enough for a scheduled digest.
+     * Consumers who want richer prose can override with {@see withModel()}.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $defaultModel = 'claude-haiku-4-5-20251001';
+
+    /**
+     * Streaming on by default — digests are longer than triage output and
+     * responders appreciate incremental rendering in the email preview.
+     *
+     * @since 1.1.0
+     *
+     * @var bool
+     */
+    public bool $stream = true;
+
+    /**
+     * System prompt describing the digest task.
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+            You are writing a periodic security digest for a stakeholder who
+            reads it out-of-band from the SIEM. You are given a window (in
+            hours), a list of anomalies detected in that window, and a small
+            aggregate summary. Your job is to produce a scannable digest.
+
+            Rules:
+              - "headline" is a single sentence (<= 100 chars) that captures
+                the most important thing in the window. If nothing notable
+                happened, say so.
+              - "body" is 3-6 sentences of plain-language narrative. No
+                bulleted lists. No jargon. No fake precision (do not invent
+                counts you were not given).
+              - "top_severities" lists the top three severity buckets by
+                count, ordered high to low. Use severities exactly as given
+                in the input (info, low, medium, high, critical). Do not
+                invent buckets that have zero anomalies.
+              - "top_detectors" lists up to three detectors that produced the
+                most anomalies in the window.
+              - "recommended_followups" is 0-3 concrete follow-ups a human
+                could act on this week. Empty list is fine.
+            PROMPT;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'headline'       => [ 'type' => 'string' ],
+                'body'           => [ 'type' => 'string' ],
+                'top_severities' => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'       => 'object',
+                        'properties' => [
+                            'severity' => [
+                                'type' => 'string',
+                                'enum' => [ 'info', 'low', 'medium', 'high', 'critical' ],
+                            ],
+                            'count' => [ 'type' => 'integer' ],
+                        ],
+                        'required' => [ 'severity', 'count' ],
+                    ],
+                ],
+                'top_detectors' => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'       => 'object',
+                        'properties' => [
+                            'detector' => [ 'type' => 'string' ],
+                            'count'    => [ 'type' => 'integer' ],
+                        ],
+                        'required' => [ 'detector', 'count' ],
+                    ],
+                ],
+                'recommended_followups' => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'string' ],
+                ],
+            ],
+            'required' => [ 'headline', 'body', 'top_severities', 'top_detectors', 'recommended_followups' ],
+        ];
+    }
+
+    /**
+     * Call the provider with the digest payload.
+     *
+     * Input shape:
+     *   - int — window in hours (agent pulls the anomalies itself).
+     *   - array with keys `window_hours` (int), `anomalies` (array of
+     *     anomaly rows), `statistics` (aggregate array). Any missing key is
+     *     hydrated from the query layer.
+     *
+     * @param  Credentials  $credentials   Resolved credentials.
+     * @param  string       $model         Resolved model identifier.
+     * @param  string       $instructions  Resolved system prompt.
+     *
+     * @return array{ output: array<string, mixed>, input_tokens: int, output_tokens: int }
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $payload = $this->payload();
+
+        return [
+            'output'        => $this->fallbackOutput( $payload ),
+            'input_tokens'  => 0,
+            'output_tokens' => 0,
+        ];
+    }
+
+    /**
+     * Digest fingerprint keyed by window + anomaly ids so a re-run with the
+     * same data hits cache.
+     */
+    protected function cacheFingerprint(): string
+    {
+        $payload = $this->payload();
+
+        $anomalyIds = array_values( array_filter( array_map(
+            static fn ( $item ) => is_array( $item ) && isset( $item['id'] ) ? (int) $item['id'] : null,
+            $payload['anomalies'] ?? [],
+        ) ) );
+
+        sort( $anomalyIds );
+
+        return 'anomaly-summary:' . hash( 'sha256', json_encode( [
+            'window'    => $payload['window_hours'] ?? 24,
+            'anomalies' => $anomalyIds,
+        ] ) );
+    }
+
+    /**
+     * @return array{ window_hours: int, anomalies: array<int, array<string, mixed>>, statistics: array<string, mixed> }
+     */
+    protected function payload(): array
+    {
+        $input = $this->input();
+
+        if ( is_int( $input ) ) {
+            return $this->buildPayloadFromWindow( $input );
+        }
+
+        if ( is_array( $input ) ) {
+            $window = $input['window_hours'] ?? 24;
+
+            if ( ! is_int( $window ) ) {
+                throw new InvalidArgumentException(
+                    'AnomalySummaryAgent: `window_hours` must be an int.',
+                );
+            }
+
+            return [
+                'window_hours' => $window,
+                'anomalies'    => array_values( $input['anomalies'] ?? $this->fetchAnomalies( $window ) ),
+                'statistics'   => $input['statistics'] ?? $this->buildStatistics( $window ),
+            ];
+        }
+
+        throw new InvalidArgumentException( sprintf(
+            'AnomalySummaryAgent: unsupported input type %s.',
+            get_debug_type( $input ),
+        ) );
+    }
+
+    /**
+     * @return array{ window_hours: int, anomalies: array<int, array<string, mixed>>, statistics: array<string, mixed> }
+     */
+    protected function buildPayloadFromWindow( int $hours ): array
+    {
+        return [
+            'window_hours' => $hours,
+            'anomalies'    => $this->fetchAnomalies( $hours ),
+            'statistics'   => $this->buildStatistics( $hours ),
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function fetchAnomalies( int $hours ): array
+    {
+        return Anomaly::query()
+            ->where( 'detected_at', '>=', now()->subHours( $hours ) )
+            ->orderByDesc( 'detected_at' )
+            ->limit( 50 )
+            ->get()
+            ->map( fn ( Anomaly $anomaly ) => [
+                'id'          => $anomaly->id,
+                'detector'    => $anomaly->detector,
+                'category'    => $anomaly->category,
+                'severity'    => $anomaly->severity,
+                'score'       => $anomaly->score,
+                'description' => $anomaly->description,
+                'detected_at' => $anomaly->detected_at?->toIso8601String(),
+            ] )
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function buildStatistics( int $hours ): array
+    {
+        $anomalies = Anomaly::query()
+            ->where( 'detected_at', '>=', now()->subHours( $hours ) )
+            ->get();
+
+        $bySeverity = $anomalies->groupBy( 'severity' )->map->count()->toArray();
+        $byDetector = $anomalies->groupBy( 'detector' )->map->count()->toArray();
+
+        arsort( $bySeverity );
+        arsort( $byDetector );
+
+        return [
+            'total_count' => $anomalies->count(),
+            'by_severity' => $bySeverity,
+            'by_detector' => $byDetector,
+        ];
+    }
+
+    /**
+     * Neutral fallback payload used until laravel/ai wiring lands.
+     *
+     * @param  array{ window_hours: int, anomalies: array<int, array<string, mixed>>, statistics: array<string, mixed> }  $payload
+     *
+     * @return array<string, mixed>
+     */
+    protected function fallbackOutput( array $payload ): array
+    {
+        $stats      = $payload['statistics'];
+        $total      = (int) ( $stats['total_count'] ?? 0 );
+        $bySeverity = $stats['by_severity'] ?? [];
+        $byDetector = $stats['by_detector'] ?? [];
+
+        $headline = 0 === $total
+            ? sprintf( 'No anomalies in the last %d hours.', $payload['window_hours'] )
+            : sprintf( '%d anomalies detected in the last %d hours.', $total, $payload['window_hours'] );
+
+        return [
+            'headline' => $headline,
+            'body'     => sprintf(
+                'Digest generation is queued for a %d-hour window with %d anomalies. Provide API credentials to enable the LLM-backed narrative.',
+                $payload['window_hours'],
+                $total,
+            ),
+            'top_severities'        => $this->topN( $bySeverity, 'severity', 3 ),
+            'top_detectors'         => $this->topN( $byDetector, 'detector', 3 ),
+            'recommended_followups' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string, int>  $buckets
+     * @param  string              $keyName
+     * @param  int                 $limit
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function topN( array $buckets, string $keyName, int $limit ): array
+    {
+        $result = [];
+
+        foreach ( array_slice( $buckets, 0, $limit, true ) as $key => $count ) {
+            $result[] = [
+                $keyName => (string) $key,
+                'count'  => (int) $count,
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/AI/Agents/AnomalySummaryAgent.php
+++ b/src/AI/Agents/AnomalySummaryAgent.php
@@ -75,19 +75,61 @@ class AnomalySummaryAgent extends ArtisanPackAgent implements Agent, HasStructur
     public string $defaultModel = 'claude-haiku-4-5-20251001';
 
     /**
-     * Streaming on by default — digests are longer than triage output and
-     * responders appreciate incremental rendering in the email preview.
+     * Streaming off. The trait's `promptStructured()` uses the non-streaming
+     * `prompt()` path and emits the assembled payload in one shot; when a
+     * streaming path lands (`stream()` on the trait), flip this back to `true`
+     * and route `execute()` through the streaming call.
      *
      * @since 1.1.0
      *
      * @var bool
      */
-    public bool $stream = true;
+    public bool $stream = false;
 
     /**
      * System prompt describing the digest task.
+     *
+     * See {@see ThreatTriageAgent::instructions()} for the layered-override
+     * plumbing. `laravel/ai` reads `instructions()` directly off the agent,
+     * so this method must consult the runtime override first.
      */
     public function instructions(): string
+    {
+        return $this->currentInstructions ?? $this->defaultInstructions();
+    }
+
+    /**
+     * Structured-output schema for laravel/ai. Single source of truth — the
+     * trait derives {@see outputSchema()} from this via `ObjectSchema`.
+     *
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema( JsonSchema $schema ): array
+    {
+        $severityBucket = $schema->object( [
+            'severity' => $schema->string()->enum( [ 'info', 'low', 'medium', 'high', 'critical' ] )->required(),
+            'count'    => $schema->integer()->required(),
+        ] );
+
+        $detectorBucket = $schema->object( [
+            'detector' => $schema->string()->required(),
+            'count'    => $schema->integer()->required(),
+        ] );
+
+        return [
+            'headline'              => $schema->string()->required(),
+            'body'                  => $schema->string()->required(),
+            'top_severities'        => $schema->array()->items( $severityBucket )->required(),
+            'top_detectors'         => $schema->array()->items( $detectorBucket )->required(),
+            'recommended_followups' => $schema->array()->items( $schema->string() )->required(),
+        ];
+    }
+
+    /**
+     * Class-default system prompt. Consumers override via the AI Settings
+     * admin UI or `artisanpack.ai.features.security.anomaly_summary.instructions`.
+     */
+    protected function defaultInstructions(): string
     {
         return <<<'PROMPT'
             You are writing a periodic security digest for a stakeholder who
@@ -114,78 +156,6 @@ class AnomalySummaryAgent extends ArtisanPackAgent implements Agent, HasStructur
     }
 
     /**
-     * @return array<string, mixed>
-     */
-    public function outputSchema(): array
-    {
-        return [
-            'type'       => 'object',
-            'properties' => [
-                'headline'       => [ 'type' => 'string' ],
-                'body'           => [ 'type' => 'string' ],
-                'top_severities' => [
-                    'type'  => 'array',
-                    'items' => [
-                        'type'       => 'object',
-                        'properties' => [
-                            'severity' => [
-                                'type' => 'string',
-                                'enum' => [ 'info', 'low', 'medium', 'high', 'critical' ],
-                            ],
-                            'count' => [ 'type' => 'integer' ],
-                        ],
-                        'required' => [ 'severity', 'count' ],
-                    ],
-                ],
-                'top_detectors' => [
-                    'type'  => 'array',
-                    'items' => [
-                        'type'       => 'object',
-                        'properties' => [
-                            'detector' => [ 'type' => 'string' ],
-                            'count'    => [ 'type' => 'integer' ],
-                        ],
-                        'required' => [ 'detector', 'count' ],
-                    ],
-                ],
-                'recommended_followups' => [
-                    'type'  => 'array',
-                    'items' => [ 'type' => 'string' ],
-                ],
-            ],
-            'required' => [ 'headline', 'body', 'top_severities', 'top_detectors', 'recommended_followups' ],
-        ];
-    }
-
-    /**
-     * Structured-output schema for laravel/ai. Mirrors {@see outputSchema()}
-     * but uses the fluent {@see JsonSchema} builder that the provider layer
-     * expects.
-     *
-     * @return array<string, \Illuminate\JsonSchema\Types\Type>
-     */
-    public function schema( JsonSchema $schema ): array
-    {
-        $severityBucket = $schema->object( [
-            'severity' => $schema->string()->enum( [ 'info', 'low', 'medium', 'high', 'critical' ] )->required(),
-            'count'    => $schema->integer()->required(),
-        ] );
-
-        $detectorBucket = $schema->object( [
-            'detector' => $schema->string()->required(),
-            'count'    => $schema->integer()->required(),
-        ] );
-
-        return [
-            'headline'              => $schema->string()->required(),
-            'body'                  => $schema->string()->required(),
-            'top_severities'        => $schema->array()->items( $severityBucket )->required(),
-            'top_detectors'         => $schema->array()->items( $detectorBucket )->required(),
-            'recommended_followups' => $schema->array()->items( $schema->string() )->required(),
-        ];
-    }
-
-    /**
      * Call the provider with the digest payload.
      *
      * Input shape:
@@ -205,6 +175,7 @@ class AnomalySummaryAgent extends ArtisanPackAgent implements Agent, HasStructur
         return $this->promptStructured(
             credentials: $credentials,
             model: $model,
+            instructions: $instructions,
             userPrompt: $this->buildUserPrompt(),
         );
     }
@@ -225,24 +196,38 @@ class AnomalySummaryAgent extends ArtisanPackAgent implements Agent, HasStructur
     }
 
     /**
-     * Digest fingerprint keyed by window + anomaly ids so a re-run with the
-     * same data hits cache.
+     * Digest fingerprint keyed by window + per-anomaly (id, severity,
+     * detector) tuples so a reclassification (severity or detector edit)
+     * invalidates the cache even when the id set hasn't changed.
      */
     protected function cacheFingerprint(): string
     {
         $payload = $this->payload();
 
-        $anomalyIds = array_values( array_filter( array_map(
-            static fn ( $item ) => is_array( $item ) && isset( $item['id'] ) ? (int) $item['id'] : null,
+        $anomalies = array_values( array_filter( array_map(
+            static fn ( $item ) => is_array( $item ) && isset( $item['id'] ) ? [
+                (int) $item['id'],
+                (string) ( $item['severity'] ?? '' ),
+                (string) ( $item['detector'] ?? '' ),
+            ] : null,
             $payload['anomalies'] ?? [],
         ) ) );
 
-        sort( $anomalyIds );
+        usort( $anomalies, static fn ( array $a, array $b ) => $a[0] <=> $b[0] );
 
-        return 'anomaly-summary:' . hash( 'sha256', json_encode( [
-            'window'    => $payload['window_hours'] ?? 24,
-            'anomalies' => $anomalyIds,
-        ] ) );
+        $encoded = json_encode(
+            [
+                'window'    => $payload['window_hours'] ?? 24,
+                'anomalies' => $anomalies,
+            ],
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE,
+        );
+
+        if ( false === $encoded ) {
+            $encoded = 'anomaly-summary:unencodable-payload';
+        }
+
+        return 'anomaly-summary:' . hash( 'sha256', $encoded );
     }
 
     /**
@@ -265,10 +250,19 @@ class AnomalySummaryAgent extends ArtisanPackAgent implements Agent, HasStructur
                 );
             }
 
+            $anomalies  = $input['anomalies'] ?? $this->fetchAnomalies( $window );
+            $statistics = $input['statistics'] ?? $this->buildStatistics( $window );
+
+            if ( ! is_array( $anomalies ) || ! is_array( $statistics ) ) {
+                throw new InvalidArgumentException(
+                    'AnomalySummaryAgent: `anomalies` and `statistics` must be arrays when provided.',
+                );
+            }
+
             return [
                 'window_hours' => $window,
-                'anomalies'    => array_values( $input['anomalies'] ?? $this->fetchAnomalies( $window ) ),
-                'statistics'   => $input['statistics'] ?? $this->buildStatistics( $window ),
+                'anomalies'    => array_values( $anomalies ),
+                'statistics'   => $statistics,
             ];
         }
 
@@ -313,22 +307,40 @@ class AnomalySummaryAgent extends ArtisanPackAgent implements Agent, HasStructur
     }
 
     /**
+     * Aggregate anomaly counts for the digest window entirely in the DB —
+     * `Anomaly::query()->get()->groupBy(...)` would hydrate every row into
+     * memory just to bucket-count it, which is unbounded on busy tenants.
+     *
      * @return array<string, mixed>
      */
     protected function buildStatistics( int $hours ): array
     {
-        $anomalies = Anomaly::query()
-            ->where( 'detected_at', '>=', now()->subHours( $hours ) )
-            ->get();
+        $since = now()->subHours( $hours );
 
-        $bySeverity = $anomalies->groupBy( 'severity' )->map->count()->toArray();
-        $byDetector = $anomalies->groupBy( 'detector' )->map->count()->toArray();
+        $bySeverity = Anomaly::query()
+            ->where( 'detected_at', '>=', $since )
+            ->selectRaw( 'severity, COUNT(*) as bucket_count' )
+            ->groupBy( 'severity' )
+            ->orderByDesc( 'bucket_count' )
+            ->pluck( 'bucket_count', 'severity' )
+            ->map( static fn ( $count ): int => (int) $count )
+            ->all();
 
-        arsort( $bySeverity );
-        arsort( $byDetector );
+        $byDetector = Anomaly::query()
+            ->where( 'detected_at', '>=', $since )
+            ->selectRaw( 'detector, COUNT(*) as bucket_count' )
+            ->groupBy( 'detector' )
+            ->orderByDesc( 'bucket_count' )
+            ->pluck( 'bucket_count', 'detector' )
+            ->map( static fn ( $count ): int => (int) $count )
+            ->all();
+
+        $totalCount = (int) Anomaly::query()
+            ->where( 'detected_at', '>=', $since )
+            ->count();
 
         return [
-            'total_count' => $anomalies->count(),
+            'total_count' => $totalCount,
             'by_severity' => $bySeverity,
             'by_detector' => $byDetector,
         ];

--- a/src/AI/Agents/AnomalySummaryAgent.php
+++ b/src/AI/Agents/AnomalySummaryAgent.php
@@ -17,8 +17,12 @@ namespace ArtisanPackUI\SecurityAnalytics\AI\Agents;
 
 use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
 use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\SecurityAnalytics\AI\Concerns\CallsLaravelAi;
 use ArtisanPackUI\SecurityAnalytics\Models\Anomaly;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use InvalidArgumentException;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
 
 /**
  * Produces a periodic (daily / weekly) digest of unusual security activity.
@@ -38,8 +42,10 @@ use InvalidArgumentException;
  *
  * @since      1.1.0
  */
-class AnomalySummaryAgent extends ArtisanPackAgent
+class AnomalySummaryAgent extends ArtisanPackAgent implements Agent, HasStructuredOutput
 {
+    use CallsLaravelAi;
+
     /**
      * Feature key registered with the AI feature registry.
      *
@@ -152,6 +158,34 @@ class AnomalySummaryAgent extends ArtisanPackAgent
     }
 
     /**
+     * Structured-output schema for laravel/ai. Mirrors {@see outputSchema()}
+     * but uses the fluent {@see JsonSchema} builder that the provider layer
+     * expects.
+     *
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema( JsonSchema $schema ): array
+    {
+        $severityBucket = $schema->object( [
+            'severity' => $schema->string()->enum( [ 'info', 'low', 'medium', 'high', 'critical' ] )->required(),
+            'count'    => $schema->integer()->required(),
+        ] );
+
+        $detectorBucket = $schema->object( [
+            'detector' => $schema->string()->required(),
+            'count'    => $schema->integer()->required(),
+        ] );
+
+        return [
+            'headline'              => $schema->string()->required(),
+            'body'                  => $schema->string()->required(),
+            'top_severities'        => $schema->array()->items( $severityBucket )->required(),
+            'top_detectors'         => $schema->array()->items( $detectorBucket )->required(),
+            'recommended_followups' => $schema->array()->items( $schema->string() )->required(),
+        ];
+    }
+
+    /**
      * Call the provider with the digest payload.
      *
      * Input shape:
@@ -168,13 +202,26 @@ class AnomalySummaryAgent extends ArtisanPackAgent
      */
     protected function execute( Credentials $credentials, string $model, string $instructions ): array
     {
+        return $this->promptStructured(
+            credentials: $credentials,
+            model: $model,
+            userPrompt: $this->buildUserPrompt(),
+        );
+    }
+
+    /**
+     * Assemble the user-role prompt sent alongside the system-role
+     * `instructions()`. The payload is a JSON snapshot of the anomaly
+     * window plus aggregate statistics.
+     */
+    protected function buildUserPrompt(): string
+    {
         $payload = $this->payload();
 
-        return [
-            'output'        => $this->fallbackOutput( $payload ),
-            'input_tokens'  => 0,
-            'output_tokens' => 0,
-        ];
+        return "Produce a security anomaly digest and return the structured JSON per the schema.\n\n"
+            . 'Window (hours): ' . $payload['window_hours'] . "\n\n"
+            . 'Anomalies in window:' . "\n" . json_encode( $payload['anomalies'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n\n"
+            . 'Aggregate statistics:' . "\n" . json_encode( $payload['statistics'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
     }
 
     /**
@@ -285,57 +332,5 @@ class AnomalySummaryAgent extends ArtisanPackAgent
             'by_severity' => $bySeverity,
             'by_detector' => $byDetector,
         ];
-    }
-
-    /**
-     * Neutral fallback payload used until laravel/ai wiring lands.
-     *
-     * @param  array{ window_hours: int, anomalies: array<int, array<string, mixed>>, statistics: array<string, mixed> }  $payload
-     *
-     * @return array<string, mixed>
-     */
-    protected function fallbackOutput( array $payload ): array
-    {
-        $stats      = $payload['statistics'];
-        $total      = (int) ( $stats['total_count'] ?? 0 );
-        $bySeverity = $stats['by_severity'] ?? [];
-        $byDetector = $stats['by_detector'] ?? [];
-
-        $headline = 0 === $total
-            ? sprintf( 'No anomalies in the last %d hours.', $payload['window_hours'] )
-            : sprintf( '%d anomalies detected in the last %d hours.', $total, $payload['window_hours'] );
-
-        return [
-            'headline' => $headline,
-            'body'     => sprintf(
-                'Digest generation is queued for a %d-hour window with %d anomalies. Provide API credentials to enable the LLM-backed narrative.',
-                $payload['window_hours'],
-                $total,
-            ),
-            'top_severities'        => $this->topN( $bySeverity, 'severity', 3 ),
-            'top_detectors'         => $this->topN( $byDetector, 'detector', 3 ),
-            'recommended_followups' => [],
-        ];
-    }
-
-    /**
-     * @param  array<string, int>  $buckets
-     * @param  string              $keyName
-     * @param  int                 $limit
-     *
-     * @return array<int, array<string, mixed>>
-     */
-    protected function topN( array $buckets, string $keyName, int $limit ): array
-    {
-        $result = [];
-
-        foreach ( array_slice( $buckets, 0, $limit, true ) as $key => $count ) {
-            $result[] = [
-                $keyName => (string) $key,
-                'count'  => (int) $count,
-            ];
-        }
-
-        return $result;
     }
 }

--- a/src/AI/Agents/IncidentResponseAgent.php
+++ b/src/AI/Agents/IncidentResponseAgent.php
@@ -83,8 +83,40 @@ class IncidentResponseAgent extends ArtisanPackAgent implements Agent, HasStruct
 
     /**
      * System prompt describing the incident-response task.
+     *
+     * See {@see ThreatTriageAgent::instructions()} for the layered-override
+     * plumbing. `laravel/ai` reads `instructions()` directly off the agent,
+     * so this method must consult the runtime override first.
      */
     public function instructions(): string
+    {
+        return $this->currentInstructions ?? $this->defaultInstructions();
+    }
+
+    /**
+     * Structured-output schema for laravel/ai. Single source of truth — the
+     * trait derives {@see outputSchema()} from this via `ObjectSchema`.
+     *
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema( JsonSchema $schema ): array
+    {
+        $suggestion = $schema->object( [
+            'step'      => $schema->string()->required(),
+            'rationale' => $schema->string()->required(),
+            'risk'      => $schema->string()->enum( [ 'low', 'medium', 'high' ] )->required(),
+        ] );
+
+        return [
+            'suggested_next_actions' => $schema->array()->items( $suggestion )->required(),
+        ];
+    }
+
+    /**
+     * Class-default system prompt. Consumers override via the AI Settings
+     * admin UI or `artisanpack.ai.features.security.incident_response.instructions`.
+     */
+    protected function defaultInstructions(): string
     {
         return <<<'PROMPT'
             You are advising an incident responder on next steps for an open
@@ -111,54 +143,6 @@ class IncidentResponseAgent extends ArtisanPackAgent implements Agent, HasStruct
     }
 
     /**
-     * @return array<string, mixed>
-     */
-    public function outputSchema(): array
-    {
-        return [
-            'type'       => 'object',
-            'properties' => [
-                'suggested_next_actions' => [
-                    'type'  => 'array',
-                    'items' => [
-                        'type'       => 'object',
-                        'properties' => [
-                            'step'      => [ 'type' => 'string' ],
-                            'rationale' => [ 'type' => 'string' ],
-                            'risk'      => [
-                                'type' => 'string',
-                                'enum' => [ 'low', 'medium', 'high' ],
-                            ],
-                        ],
-                        'required' => [ 'step', 'rationale', 'risk' ],
-                    ],
-                ],
-            ],
-            'required' => [ 'suggested_next_actions' ],
-        ];
-    }
-
-    /**
-     * Structured-output schema for laravel/ai. Mirrors {@see outputSchema()}
-     * but uses the fluent {@see JsonSchema} builder that the provider layer
-     * expects.
-     *
-     * @return array<string, \Illuminate\JsonSchema\Types\Type>
-     */
-    public function schema( JsonSchema $schema ): array
-    {
-        $suggestion = $schema->object( [
-            'step'      => $schema->string()->required(),
-            'rationale' => $schema->string()->required(),
-            'risk'      => $schema->string()->enum( [ 'low', 'medium', 'high' ] )->required(),
-        ] );
-
-        return [
-            'suggested_next_actions' => $schema->array()->items( $suggestion )->required(),
-        ];
-    }
-
-    /**
      * Build the LLM input from incident state, timeline, and playbooks.
      *
      * Input shape:
@@ -178,6 +162,7 @@ class IncidentResponseAgent extends ArtisanPackAgent implements Agent, HasStruct
         return $this->promptStructured(
             credentials: $credentials,
             model: $model,
+            instructions: $instructions,
             userPrompt: $this->buildUserPrompt(),
         );
     }
@@ -198,18 +183,30 @@ class IncidentResponseAgent extends ArtisanPackAgent implements Agent, HasStruct
     }
 
     /**
-     * Fingerprint that includes the incident's updated_at so re-running the
-     * agent after new timeline entries invalidates the cache.
+     * Fingerprint that hashes the timeline contents (not just the count) so
+     * a same-length edit — replacing an action, reordering, or a bulk
+     * update that skips `updated_at` — properly invalidates the cache.
      */
     protected function cacheFingerprint(): string
     {
         $payload = $this->payload();
 
-        return 'incident-response:' . hash( 'sha256', json_encode( [
-            'incident_id'    => $payload['incident']['id'] ?? null,
-            'timeline_count' => count( $payload['timeline'] ?? [] ),
-            'updated_at'     => $payload['incident']['updated_at'] ?? null,
-        ] ) );
+        $encoded = json_encode(
+            [
+                'incident_id' => $payload['incident']['id'] ?? null,
+                'severity'    => $payload['incident']['severity'] ?? null,
+                'status'      => $payload['incident']['status'] ?? null,
+                'updated_at'  => $payload['incident']['updated_at'] ?? null,
+                'timeline'    => $payload['timeline'] ?? [],
+            ],
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE,
+        );
+
+        if ( false === $encoded ) {
+            $encoded = 'incident-response:unencodable-payload';
+        }
+
+        return 'incident-response:' . hash( 'sha256', $encoded );
     }
 
     /**

--- a/src/AI/Agents/IncidentResponseAgent.php
+++ b/src/AI/Agents/IncidentResponseAgent.php
@@ -17,9 +17,13 @@ namespace ArtisanPackUI\SecurityAnalytics\AI\Agents;
 
 use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
 use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\SecurityAnalytics\AI\Concerns\CallsLaravelAi;
 use ArtisanPackUI\SecurityAnalytics\Models\ResponsePlaybook;
 use ArtisanPackUI\SecurityAnalytics\Models\SecurityIncident;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use InvalidArgumentException;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
 
 /**
  * Suggests next steps for a security incident.
@@ -35,8 +39,10 @@ use InvalidArgumentException;
  *
  * @since      1.1.0
  */
-class IncidentResponseAgent extends ArtisanPackAgent
+class IncidentResponseAgent extends ArtisanPackAgent implements Agent, HasStructuredOutput
 {
+    use CallsLaravelAi;
+
     /**
      * Feature key registered with the AI feature registry.
      *
@@ -133,6 +139,26 @@ class IncidentResponseAgent extends ArtisanPackAgent
     }
 
     /**
+     * Structured-output schema for laravel/ai. Mirrors {@see outputSchema()}
+     * but uses the fluent {@see JsonSchema} builder that the provider layer
+     * expects.
+     *
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema( JsonSchema $schema ): array
+    {
+        $suggestion = $schema->object( [
+            'step'      => $schema->string()->required(),
+            'rationale' => $schema->string()->required(),
+            'risk'      => $schema->string()->enum( [ 'low', 'medium', 'high' ] )->required(),
+        ] );
+
+        return [
+            'suggested_next_actions' => $schema->array()->items( $suggestion )->required(),
+        ];
+    }
+
+    /**
      * Build the LLM input from incident state, timeline, and playbooks.
      *
      * Input shape:
@@ -149,13 +175,26 @@ class IncidentResponseAgent extends ArtisanPackAgent
      */
     protected function execute( Credentials $credentials, string $model, string $instructions ): array
     {
+        return $this->promptStructured(
+            credentials: $credentials,
+            model: $model,
+            userPrompt: $this->buildUserPrompt(),
+        );
+    }
+
+    /**
+     * Assemble the user-role prompt sent alongside the system-role
+     * `instructions()`. The payload is a JSON snapshot of the incident
+     * state, its action timeline, and any matching playbooks.
+     */
+    protected function buildUserPrompt(): string
+    {
         $payload = $this->payload();
 
-        return [
-            'output'        => $this->fallbackOutput( $payload ),
-            'input_tokens'  => 0,
-            'output_tokens' => 0,
-        ];
+        return "Advise on next steps for the following security incident and return the structured JSON per the schema.\n\n"
+            . 'Incident:' . "\n" . json_encode( $payload['incident'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n\n"
+            . 'Timeline so far:' . "\n" . json_encode( $payload['timeline'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n\n"
+            . 'Matching playbooks:' . "\n" . json_encode( $payload['playbooks'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
     }
 
     /**
@@ -276,20 +315,6 @@ class IncidentResponseAgent extends ArtisanPackAgent
             'description'       => $playbook->description,
             'actions'           => $playbook->getActionNames(),
             'requires_approval' => (bool) $playbook->requires_approval,
-        ];
-    }
-
-    /**
-     * Neutral fallback payload used until laravel/ai wiring lands.
-     *
-     * @param  array{ incident: array<string, mixed>, timeline: array<int, array<string, mixed>>, playbooks: array<int, array<string, mixed>> }  $payload
-     *
-     * @return array<string, mixed>
-     */
-    protected function fallbackOutput( array $payload ): array
-    {
-        return [
-            'suggested_next_actions' => [],
         ];
     }
 }

--- a/src/AI/Agents/IncidentResponseAgent.php
+++ b/src/AI/Agents/IncidentResponseAgent.php
@@ -1,0 +1,295 @@
+<?php
+
+/**
+ * IncidentResponseAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAnalytics\AI\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\SecurityAnalytics\Models\ResponsePlaybook;
+use ArtisanPackUI\SecurityAnalytics\Models\SecurityIncident;
+use InvalidArgumentException;
+
+/**
+ * Suggests next steps for a security incident.
+ *
+ * Reads the current {@see SecurityIncident} state, timeline of actions taken
+ * so far, and any matching {@see ResponsePlaybook}s, and returns a small,
+ * ordered list of next actions with rationale and risk. Suggestion only —
+ * this agent never triggers any action; execution stays in the human's
+ * hands via {@see \ArtisanPackUI\SecurityAnalytics\Analytics\IncidentResponse\IncidentResponder}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @since      1.1.0
+ */
+class IncidentResponseAgent extends ArtisanPackAgent
+{
+    /**
+     * Feature key registered with the AI feature registry.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $featureKey = 'security.incident_response';
+
+    /**
+     * Owning composer package.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $package = 'artisanpack-ui/security-analytics';
+
+    /**
+     * Default model — Opus 4.7. Incident response reasoning is the highest-
+     * stakes surface in this package and warrants the deepest model tier.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $defaultModel = 'claude-opus-4-7';
+
+    /**
+     * Streaming off — the caller is a human deciding what to do next and
+     * they want the full ordered list, not a partial stream.
+     *
+     * @since 1.1.0
+     *
+     * @var bool
+     */
+    public bool $stream = false;
+
+    /**
+     * System prompt describing the incident-response task.
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+            You are advising an incident responder on next steps for an open
+            security incident. You are given the incident state, its
+            timeline of actions taken so far, and one or more playbooks that
+            match the underlying anomaly.
+
+            Rules:
+              - Suggest 1-4 "suggested_next_actions", ordered by what should
+                happen first. Do not repeat actions already recorded in the
+                timeline unless there is a specific reason to re-run.
+              - Each "step" is a concrete, single-line action a responder can
+                execute (e.g. "Rotate the compromised API token") — not a
+                philosophy.
+              - Each "rationale" is one sentence explaining why this step is
+                worth taking given the current state.
+              - Each "risk" is one of: low, medium, high — reflecting the
+                impact-if-wrong of taking this step (not the severity of the
+                incident itself).
+              - Do NOT trigger actions. Your output is advisory only.
+              - Prefer steps that appear in the provided playbooks; only
+                deviate when the playbook does not fit the current state.
+            PROMPT;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'suggested_next_actions' => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'       => 'object',
+                        'properties' => [
+                            'step'      => [ 'type' => 'string' ],
+                            'rationale' => [ 'type' => 'string' ],
+                            'risk'      => [
+                                'type' => 'string',
+                                'enum' => [ 'low', 'medium', 'high' ],
+                            ],
+                        ],
+                        'required' => [ 'step', 'rationale', 'risk' ],
+                    ],
+                ],
+            ],
+            'required' => [ 'suggested_next_actions' ],
+        ];
+    }
+
+    /**
+     * Build the LLM input from incident state, timeline, and playbooks.
+     *
+     * Input shape:
+     *   - int — a {@see SecurityIncident} id (agent hydrates state + playbooks).
+     *   - {@see SecurityIncident} — the incident model.
+     *   - array with keys `incident` (array), `timeline` (array), `playbooks`
+     *     (array). All keys required when passing an array.
+     *
+     * @param  Credentials  $credentials   Resolved credentials.
+     * @param  string       $model         Resolved model identifier.
+     * @param  string       $instructions  Resolved system prompt.
+     *
+     * @return array{ output: array<string, mixed>, input_tokens: int, output_tokens: int }
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $payload = $this->payload();
+
+        return [
+            'output'        => $this->fallbackOutput( $payload ),
+            'input_tokens'  => 0,
+            'output_tokens' => 0,
+        ];
+    }
+
+    /**
+     * Fingerprint that includes the incident's updated_at so re-running the
+     * agent after new timeline entries invalidates the cache.
+     */
+    protected function cacheFingerprint(): string
+    {
+        $payload = $this->payload();
+
+        return 'incident-response:' . hash( 'sha256', json_encode( [
+            'incident_id'    => $payload['incident']['id'] ?? null,
+            'timeline_count' => count( $payload['timeline'] ?? [] ),
+            'updated_at'     => $payload['incident']['updated_at'] ?? null,
+        ] ) );
+    }
+
+    /**
+     * @return array{ incident: array<string, mixed>, timeline: array<int, array<string, mixed>>, playbooks: array<int, array<string, mixed>> }
+     */
+    protected function payload(): array
+    {
+        $input = $this->input();
+
+        if ( $input instanceof SecurityIncident ) {
+            return $this->buildPayloadFromIncident( $input );
+        }
+
+        if ( is_int( $input ) ) {
+            $incident = SecurityIncident::query()->find( $input );
+
+            if ( null === $incident ) {
+                throw new InvalidArgumentException(
+                    sprintf( 'IncidentResponseAgent: SecurityIncident %d not found.', $input ),
+                );
+            }
+
+            return $this->buildPayloadFromIncident( $incident );
+        }
+
+        if ( is_array( $input ) ) {
+            $incident  = $input['incident'] ?? null;
+            $timeline  = $input['timeline'] ?? null;
+            $playbooks = $input['playbooks'] ?? null;
+
+            if ( ! is_array( $incident ) || ! is_array( $timeline ) || ! is_array( $playbooks ) ) {
+                throw new InvalidArgumentException(
+                    'IncidentResponseAgent: array input requires `incident`, `timeline`, `playbooks` arrays.',
+                );
+            }
+
+            return [
+                'incident'  => $incident,
+                'timeline'  => array_values( $timeline ),
+                'playbooks' => array_values( $playbooks ),
+            ];
+        }
+
+        throw new InvalidArgumentException( sprintf(
+            'IncidentResponseAgent: unsupported input type %s.',
+            get_debug_type( $input ),
+        ) );
+    }
+
+    /**
+     * @return array{ incident: array<string, mixed>, timeline: array<int, array<string, mixed>>, playbooks: array<int, array<string, mixed>> }
+     */
+    protected function buildPayloadFromIncident( SecurityIncident $incident ): array
+    {
+        $playbooks = [];
+
+        if ( null !== $incident->sourceAnomaly ) {
+            $playbooks = ResponsePlaybook::query()
+                ->where( 'is_active', true )
+                ->get()
+                ->filter( fn ( ResponsePlaybook $playbook ) => $playbook->matchesAnomaly( $incident->sourceAnomaly ) )
+                ->values()
+                ->all();
+        }
+
+        return [
+            'incident'  => $this->serializeIncident( $incident ),
+            'timeline'  => array_values( $incident->actions_taken ?? [] ),
+            'playbooks' => array_map( fn ( ResponsePlaybook $playbook ) => $this->serializePlaybook( $playbook ), $playbooks ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function serializeIncident( SecurityIncident $incident ): array
+    {
+        return [
+            'id'              => $incident->id,
+            'incident_number' => $incident->incident_number,
+            'title'           => $incident->title,
+            'description'     => $incident->description,
+            'severity'        => $incident->severity,
+            'status'          => $incident->status,
+            'category'        => $incident->category,
+            'affected_users'  => $incident->affected_users ?? [],
+            'affected_ips'    => $incident->affected_ips ?? [],
+            'opened_at'       => $incident->opened_at?->toIso8601String(),
+            'contained_at'    => $incident->contained_at?->toIso8601String(),
+            'resolved_at'     => $incident->resolved_at?->toIso8601String(),
+            'updated_at'      => $incident->updated_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function serializePlaybook( ResponsePlaybook $playbook ): array
+    {
+        return [
+            'id'                => $playbook->id,
+            'name'              => $playbook->name,
+            'description'       => $playbook->description,
+            'actions'           => $playbook->getActionNames(),
+            'requires_approval' => (bool) $playbook->requires_approval,
+        ];
+    }
+
+    /**
+     * Neutral fallback payload used until laravel/ai wiring lands.
+     *
+     * @param  array{ incident: array<string, mixed>, timeline: array<int, array<string, mixed>>, playbooks: array<int, array<string, mixed>> }  $payload
+     *
+     * @return array<string, mixed>
+     */
+    protected function fallbackOutput( array $payload ): array
+    {
+        return [
+            'suggested_next_actions' => [],
+        ];
+    }
+}

--- a/src/AI/Agents/ThreatTriageAgent.php
+++ b/src/AI/Agents/ThreatTriageAgent.php
@@ -85,8 +85,45 @@ class ThreatTriageAgent extends ArtisanPackAgent implements Agent, HasStructured
 
     /**
      * System prompt describing the triage task.
+     *
+     * Layered precedence: the base pipeline computes a resolved instructions
+     * string (settings-store override → config override → class default) and
+     * hands it to `execute()`, which stashes it on the trait's
+     * `$currentInstructions` for the duration of the run. `laravel/ai` reads
+     * `instructions()` directly off the agent, so this method must consult
+     * the runtime override first.
      */
     public function instructions(): string
+    {
+        return $this->currentInstructions ?? $this->defaultInstructions();
+    }
+
+    /**
+     * Structured-output schema for laravel/ai. Single source of truth — the
+     * trait derives {@see outputSchema()} from this via `ObjectSchema`.
+     *
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema( JsonSchema $schema ): array
+    {
+        $action = $schema->object( [
+            'step'    => $schema->string()->required(),
+            'urgency' => $schema->string()->enum( [ 'immediate', 'high', 'medium', 'low' ] )->required(),
+        ] );
+
+        return [
+            'severity'            => $schema->string()->enum( [ 'info', 'low', 'medium', 'high', 'critical' ] )->required(),
+            'summary'             => $schema->string()->required(),
+            'recommended_actions' => $schema->array()->items( $action )->required(),
+            'related_events'      => $schema->array()->items( $schema->integer() )->required(),
+        ];
+    }
+
+    /**
+     * Class-default system prompt. Consumers override via the AI Settings
+     * admin UI or `artisanpack.ai.features.security.threat_triage.instructions`.
+     */
+    protected function defaultInstructions(): string
     {
         return <<<'PROMPT'
             You are a senior on-call security responder. You are given a
@@ -104,67 +141,6 @@ class ThreatTriageAgent extends ArtisanPackAgent implements Agent, HasStructured
                 related context. Do not invent event ids.
               - You never trigger actions. Your output is advisory only.
             PROMPT;
-    }
-
-    /**
-     * Structured output schema. The base pipeline validates the LLM response
-     * against this shape before returning.
-     *
-     * @return array<string, mixed>
-     */
-    public function outputSchema(): array
-    {
-        return [
-            'type'       => 'object',
-            'properties' => [
-                'severity' => [
-                    'type' => 'string',
-                    'enum' => [ 'info', 'low', 'medium', 'high', 'critical' ],
-                ],
-                'summary'             => [ 'type' => 'string' ],
-                'recommended_actions' => [
-                    'type'  => 'array',
-                    'items' => [
-                        'type'       => 'object',
-                        'properties' => [
-                            'step'    => [ 'type' => 'string' ],
-                            'urgency' => [
-                                'type' => 'string',
-                                'enum' => [ 'immediate', 'high', 'medium', 'low' ],
-                            ],
-                        ],
-                        'required' => [ 'step', 'urgency' ],
-                    ],
-                ],
-                'related_events' => [
-                    'type'  => 'array',
-                    'items' => [ 'type' => 'integer' ],
-                ],
-            ],
-            'required' => [ 'severity', 'summary', 'recommended_actions', 'related_events' ],
-        ];
-    }
-
-    /**
-     * Structured-output schema for laravel/ai. Mirrors {@see outputSchema()}
-     * but uses the fluent {@see JsonSchema} builder that the provider layer
-     * expects.
-     *
-     * @return array<string, \Illuminate\JsonSchema\Types\Type>
-     */
-    public function schema( JsonSchema $schema ): array
-    {
-        $action = $schema->object( [
-            'step'    => $schema->string()->required(),
-            'urgency' => $schema->string()->enum( [ 'immediate', 'high', 'medium', 'low' ] )->required(),
-        ] );
-
-        return [
-            'severity'            => $schema->string()->enum( [ 'info', 'low', 'medium', 'high', 'critical' ] )->required(),
-            'summary'             => $schema->string()->required(),
-            'recommended_actions' => $schema->array()->items( $action )->required(),
-            'related_events'      => $schema->array()->items( $schema->integer() )->required(),
-        ];
     }
 
     /**
@@ -191,6 +167,7 @@ class ThreatTriageAgent extends ArtisanPackAgent implements Agent, HasStructured
         return $this->promptStructured(
             credentials: $credentials,
             model: $model,
+            instructions: $instructions,
             userPrompt: $this->buildUserPrompt(),
         );
     }
@@ -217,12 +194,19 @@ class ThreatTriageAgent extends ArtisanPackAgent implements Agent, HasStructured
      */
     protected function cacheFingerprint(): string
     {
-        $payload = $this->payload();
-
-        return 'threat-triage:' . hash(
-            'sha256',
-            json_encode( $payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+        $encoded = json_encode(
+            $this->payload(),
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE,
         );
+
+        // Under strict types, hash() rejects a false return. Fall through
+        // to a deterministic marker so an unencodable payload doesn't crash
+        // the base pipeline before execute() runs.
+        if ( false === $encoded ) {
+            $encoded = 'threat-triage:unencodable-payload';
+        }
+
+        return 'threat-triage:' . hash( 'sha256', $encoded );
     }
 
     /**
@@ -291,6 +275,18 @@ class ThreatTriageAgent extends ArtisanPackAgent implements Agent, HasStructured
      */
     protected function fetchRelated( SecurityEvent $event ): array
     {
+        // Empty closure-wheres are a no-op in Eloquent, which would return
+        // arbitrary recent events across all tenants/users and leak their
+        // PII into the LLM prompt. Skip the query entirely when we have no
+        // correlation keys to filter on.
+        if (
+            null === $event->fingerprint
+            && null === $event->ip_address
+            && null === $event->user_id
+        ) {
+            return [];
+        }
+
         return SecurityEvent::query()
             ->where( 'id', '!=', $event->id )
             ->where( function ( $query ) use ( $event ): void {

--- a/src/AI/Agents/ThreatTriageAgent.php
+++ b/src/AI/Agents/ThreatTriageAgent.php
@@ -17,8 +17,12 @@ namespace ArtisanPackUI\SecurityAnalytics\AI\Agents;
 
 use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
 use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\SecurityAnalytics\AI\Concerns\CallsLaravelAi;
 use ArtisanPackUI\SecurityAnalytics\Models\SecurityEvent;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use InvalidArgumentException;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
 
 /**
  * Generates a plain-language triage of a security event.
@@ -37,8 +41,10 @@ use InvalidArgumentException;
  *
  * @since      1.1.0
  */
-class ThreatTriageAgent extends ArtisanPackAgent
+class ThreatTriageAgent extends ArtisanPackAgent implements Agent, HasStructuredOutput
 {
+    use CallsLaravelAi;
+
     /**
      * Feature key registered with the AI feature registry.
      *
@@ -140,6 +146,28 @@ class ThreatTriageAgent extends ArtisanPackAgent
     }
 
     /**
+     * Structured-output schema for laravel/ai. Mirrors {@see outputSchema()}
+     * but uses the fluent {@see JsonSchema} builder that the provider layer
+     * expects.
+     *
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    public function schema( JsonSchema $schema ): array
+    {
+        $action = $schema->object( [
+            'step'    => $schema->string()->required(),
+            'urgency' => $schema->string()->enum( [ 'immediate', 'high', 'medium', 'low' ] )->required(),
+        ] );
+
+        return [
+            'severity'            => $schema->string()->enum( [ 'info', 'low', 'medium', 'high', 'critical' ] )->required(),
+            'summary'             => $schema->string()->required(),
+            'recommended_actions' => $schema->array()->items( $action )->required(),
+            'related_events'      => $schema->array()->items( $schema->integer() )->required(),
+        ];
+    }
+
+    /**
      * Build the LLM input from the raw event, recent-event window, and
      * optional user context.
      *
@@ -160,17 +188,26 @@ class ThreatTriageAgent extends ArtisanPackAgent
      */
     protected function execute( Credentials $credentials, string $model, string $instructions ): array
     {
-        // Concrete provider delegation lands with laravel/ai wiring in a
-        // follow-up. For now the pipeline (feature gate → credential resolve
-        // → cache → dispatch) is exercised against the resolved payload
-        // below, which mirrors what the provider call will consume.
+        return $this->promptStructured(
+            credentials: $credentials,
+            model: $model,
+            userPrompt: $this->buildUserPrompt(),
+        );
+    }
+
+    /**
+     * Assemble the user-role prompt sent alongside the system-role
+     * `instructions()`. The payload is a JSON snapshot of the event, its
+     * related-event window, and any extra context.
+     */
+    protected function buildUserPrompt(): string
+    {
         $payload = $this->payload();
 
-        return [
-            'output'        => $this->fallbackOutput( $payload ),
-            'input_tokens'  => 0,
-            'output_tokens' => 0,
-        ];
+        return "Triage the following security event and return the structured JSON per the schema.\n\n"
+            . 'Event:' . "\n" . json_encode( $payload['event'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n\n"
+            . 'Recent related events:' . "\n" . json_encode( $payload['related'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n\n"
+            . 'Additional context:' . "\n" . json_encode( $payload['context'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
     }
 
     /**
@@ -305,41 +342,5 @@ class ThreatTriageAgent extends ArtisanPackAgent
     protected function serializeRelated( array $events ): array
     {
         return array_map( fn ( SecurityEvent $event ) => $this->serializeEvent( $event ), $events );
-    }
-
-    /**
-     * Neutral fallback used while the provider call is stubbed. Downstream
-     * `execute()` will replace this once laravel/ai wiring lands; keeping it
-     * shape-valid lets the Livewire trigger surface render without failing
-     * schema validation.
-     *
-     * @param  array<string, mixed>  $payload
-     *
-     * @return array<string, mixed>
-     */
-    protected function fallbackOutput( array $payload ): array
-    {
-        $event    = $payload['event'] ?? [];
-        $severity = is_string( $event['severity'] ?? null ) ? $event['severity'] : 'info';
-        $summary  = sprintf(
-            'Threat triage is queued for event %s. Provide API credentials to enable the LLM-backed summary.',
-            (string) ( $event['id'] ?? 'unknown' ),
-        );
-
-        $related = array_values( array_filter( array_map(
-            static fn ( array $item ): ?int => isset( $item['id'] ) && is_numeric( $item['id'] ) ? (int) $item['id'] : null,
-            $payload['related'] ?? [],
-        ) ) );
-
-        return [
-            'severity'            => in_array(
-                $severity,
-                [ 'info', 'low', 'medium', 'high', 'critical' ],
-                true,
-            ) ? $severity : 'info',
-            'summary'             => $summary,
-            'recommended_actions' => [],
-            'related_events'      => $related,
-        ];
     }
 }

--- a/src/AI/Agents/ThreatTriageAgent.php
+++ b/src/AI/Agents/ThreatTriageAgent.php
@@ -1,0 +1,345 @@
+<?php
+
+/**
+ * ThreatTriageAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAnalytics\AI\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\SecurityAnalytics\Models\SecurityEvent;
+use InvalidArgumentException;
+
+/**
+ * Generates a plain-language triage of a security event.
+ *
+ * Given a raw {@see SecurityEvent} (or an event id / array of event data) the
+ * agent returns a structured triage: normalized severity, a short summary the
+ * on-call responder can scan, an ordered list of recommended actions with
+ * urgency, and the ids of related events surfaced from the last 24 hours.
+ *
+ * The output is advisory only — the agent never triggers any response action
+ * itself. See {@see \ArtisanPackUI\SecurityAnalytics\Analytics\IncidentResponse\IncidentResponder}
+ * for the execution surface.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @since      1.1.0
+ */
+class ThreatTriageAgent extends ArtisanPackAgent
+{
+    /**
+     * Feature key registered with the AI feature registry.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $featureKey = 'security.threat_triage';
+
+    /**
+     * Owning composer package.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $package = 'artisanpack-ui/security-analytics';
+
+    /**
+     * Default model — Sonnet 4.6 balances triage speed with sufficient
+     * reasoning to weigh related-event context.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    public string $defaultModel = 'claude-sonnet-4-6';
+
+    /**
+     * Streaming is off — triage output is short and consumers want the full
+     * structured payload before rendering.
+     *
+     * @since 1.1.0
+     *
+     * @var bool
+     */
+    public bool $stream = false;
+
+    /**
+     * System prompt describing the triage task.
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+            You are a senior on-call security responder. You are given a
+            security event, a small window of recent related events, and
+            optional user/asset context. Your job is to produce a short,
+            actionable triage a human responder can scan in under 30 seconds.
+
+            Rules:
+              - Choose exactly one severity from: info, low, medium, high, critical.
+              - Write "summary" as one or two sentences, plain language, no jargon.
+              - Provide 1-4 "recommended_actions" ordered from highest urgency to
+                lowest. Each action's "urgency" is one of: immediate, high,
+                medium, low.
+              - Only include ids in "related_events" that were passed in as
+                related context. Do not invent event ids.
+              - You never trigger actions. Your output is advisory only.
+            PROMPT;
+    }
+
+    /**
+     * Structured output schema. The base pipeline validates the LLM response
+     * against this shape before returning.
+     *
+     * @return array<string, mixed>
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'severity' => [
+                    'type' => 'string',
+                    'enum' => [ 'info', 'low', 'medium', 'high', 'critical' ],
+                ],
+                'summary'             => [ 'type' => 'string' ],
+                'recommended_actions' => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'       => 'object',
+                        'properties' => [
+                            'step'    => [ 'type' => 'string' ],
+                            'urgency' => [
+                                'type' => 'string',
+                                'enum' => [ 'immediate', 'high', 'medium', 'low' ],
+                            ],
+                        ],
+                        'required' => [ 'step', 'urgency' ],
+                    ],
+                ],
+                'related_events' => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'integer' ],
+                ],
+            ],
+            'required' => [ 'severity', 'summary', 'recommended_actions', 'related_events' ],
+        ];
+    }
+
+    /**
+     * Build the LLM input from the raw event, recent-event window, and
+     * optional user context.
+     *
+     * Input shape accepted by {@see ArtisanPackAgent::for()}:
+     *   - int — a {@see SecurityEvent} id
+     *   - {@see SecurityEvent} — the model itself
+     *   - array with keys `event` (event array), `related` (array of events),
+     *     `context` (arbitrary context)
+     *
+     * The prompt returns everything the LLM needs; nothing here talks to
+     * providers directly. Base `execute()` overrides call `laravel/ai`.
+     *
+     * @param  Credentials  $credentials   Resolved credentials.
+     * @param  string       $model         Resolved model identifier.
+     * @param  string       $instructions  Resolved system prompt.
+     *
+     * @return array{ output: array<string, mixed>, input_tokens: int, output_tokens: int }
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        // Concrete provider delegation lands with laravel/ai wiring in a
+        // follow-up. For now the pipeline (feature gate → credential resolve
+        // → cache → dispatch) is exercised against the resolved payload
+        // below, which mirrors what the provider call will consume.
+        $payload = $this->payload();
+
+        return [
+            'output'        => $this->fallbackOutput( $payload ),
+            'input_tokens'  => 0,
+            'output_tokens' => 0,
+        ];
+    }
+
+    /**
+     * Deterministic cache fingerprint for structured inputs. The base class
+     * throws for non-scalar inputs; triage always takes a model or an array,
+     * so override with an event-id-and-context digest.
+     */
+    protected function cacheFingerprint(): string
+    {
+        $payload = $this->payload();
+
+        return 'threat-triage:' . hash(
+            'sha256',
+            json_encode( $payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+        );
+    }
+
+    /**
+     * Normalize the input into a `{event, related, context}` payload the
+     * provider (and cache fingerprint) can rely on.
+     *
+     * @return array{ event: array<string, mixed>, related: array<int, array<string, mixed>>, context: array<string, mixed> }
+     */
+    protected function payload(): array
+    {
+        $input = $this->input();
+
+        if ( $input instanceof SecurityEvent ) {
+            return [
+                'event'   => $this->serializeEvent( $input ),
+                'related' => $this->serializeRelated( $this->fetchRelated( $input ) ),
+                'context' => [],
+            ];
+        }
+
+        if ( is_int( $input ) ) {
+            $event = SecurityEvent::query()->find( $input );
+
+            if ( null === $event ) {
+                throw new InvalidArgumentException(
+                    sprintf( 'ThreatTriageAgent: SecurityEvent %d not found.', $input ),
+                );
+            }
+
+            return [
+                'event'   => $this->serializeEvent( $event ),
+                'related' => $this->serializeRelated( $this->fetchRelated( $event ) ),
+                'context' => [],
+            ];
+        }
+
+        if ( is_array( $input ) ) {
+            $event   = $input['event'] ?? [];
+            $related = $input['related'] ?? [];
+            $context = $input['context'] ?? [];
+
+            if ( ! is_array( $event ) || ! is_array( $related ) || ! is_array( $context ) ) {
+                throw new InvalidArgumentException(
+                    'ThreatTriageAgent: array input must have `event`, `related`, `context` keys as arrays.',
+                );
+            }
+
+            return [
+                'event'   => $event,
+                'related' => array_values( $related ),
+                'context' => $context,
+            ];
+        }
+
+        throw new InvalidArgumentException( sprintf(
+            'ThreatTriageAgent: unsupported input type %s.',
+            get_debug_type( $input ),
+        ) );
+    }
+
+    /**
+     * Recent related events sharing the same fingerprint, IP, or user in the
+     * last 24 hours (excluding the primary event).
+     *
+     * @return array<int, SecurityEvent>
+     */
+    protected function fetchRelated( SecurityEvent $event ): array
+    {
+        return SecurityEvent::query()
+            ->where( 'id', '!=', $event->id )
+            ->where( function ( $query ) use ( $event ): void {
+                if ( null !== $event->fingerprint ) {
+                    $query->orWhere( 'fingerprint', $event->fingerprint );
+                }
+
+                if ( null !== $event->ip_address ) {
+                    $query->orWhere( 'ip_address', $event->ip_address );
+                }
+
+                if ( null !== $event->user_id ) {
+                    $query->orWhere( 'user_id', $event->user_id );
+                }
+            } )
+            ->recent( 24 )
+            ->latest( 'created_at' )
+            ->limit( 10 )
+            ->get()
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function serializeEvent( SecurityEvent $event ): array
+    {
+        return [
+            'id'          => $event->id,
+            'event_type'  => $event->event_type,
+            'event_name'  => $event->event_name,
+            'severity'    => $event->severity,
+            'user_id'     => $event->user_id,
+            'ip_address'  => $event->ip_address,
+            'url'         => $event->url,
+            'method'      => $event->method,
+            'status_code' => $event->status_code,
+            'details'     => $event->details ?? [],
+            'fingerprint' => $event->fingerprint,
+            'created_at'  => $event->created_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param  array<int, SecurityEvent>  $events
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function serializeRelated( array $events ): array
+    {
+        return array_map( fn ( SecurityEvent $event ) => $this->serializeEvent( $event ), $events );
+    }
+
+    /**
+     * Neutral fallback used while the provider call is stubbed. Downstream
+     * `execute()` will replace this once laravel/ai wiring lands; keeping it
+     * shape-valid lets the Livewire trigger surface render without failing
+     * schema validation.
+     *
+     * @param  array<string, mixed>  $payload
+     *
+     * @return array<string, mixed>
+     */
+    protected function fallbackOutput( array $payload ): array
+    {
+        $event    = $payload['event'] ?? [];
+        $severity = is_string( $event['severity'] ?? null ) ? $event['severity'] : 'info';
+        $summary  = sprintf(
+            'Threat triage is queued for event %s. Provide API credentials to enable the LLM-backed summary.',
+            (string) ( $event['id'] ?? 'unknown' ),
+        );
+
+        $related = array_values( array_filter( array_map(
+            static fn ( array $item ): ?int => isset( $item['id'] ) && is_numeric( $item['id'] ) ? (int) $item['id'] : null,
+            $payload['related'] ?? [],
+        ) ) );
+
+        return [
+            'severity'            => in_array(
+                $severity,
+                [ 'info', 'low', 'medium', 'high', 'critical' ],
+                true,
+            ) ? $severity : 'info',
+            'summary'             => $summary,
+            'recommended_actions' => [],
+            'related_events'      => $related,
+        ];
+    }
+}

--- a/src/AI/Concerns/CallsLaravelAi.php
+++ b/src/AI/Concerns/CallsLaravelAi.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Shared laravel/ai wiring for the security-analytics AI agents.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAnalytics\AI\Concerns;
+
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Responses\StructuredAgentResponse;
+use RuntimeException;
+
+/**
+ * Concrete provider delegation for the three security-analytics agents.
+ *
+ * Each agent extends {@see \ArtisanPackUI\Ai\Agents\ArtisanPackAgent} and
+ * inherits the frozen v1.x pipeline (feature gate, credential resolver,
+ * cache, `AgentUsageRecorded` dispatch). This trait pulls in `laravel/ai`'s
+ * {@see Promptable} so subclasses can call `$this->promptStructured()` from
+ * their `execute()` implementation to talk to the resolved provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @since      1.1.0
+ */
+trait CallsLaravelAi
+{
+    use Promptable;
+
+    /**
+     * Invoke `laravel/ai` and unpack the structured response into the
+     * envelope the {@see ArtisanPackAgent::run()} pipeline expects.
+     *
+     * The credentials passed here come from the base pipeline's resolver
+     * chain — they're pushed into the `ai.providers.{provider}` config
+     * slot so `laravel/ai`'s manager resolves against the right key /
+     * base URL. This is scoped to the current request and safe to repeat.
+     *
+     * @param  Credentials  $credentials  Resolved provider credentials.
+     * @param  string       $model        Resolved model identifier.
+     * @param  string       $userPrompt   The user-role prompt body.
+     *
+     * @return array{ output: array<string, mixed>, input_tokens: int, output_tokens: int }
+     */
+    protected function promptStructured(
+        Credentials $credentials,
+        string $model,
+        string $userPrompt,
+    ): array {
+        $this->configureProvider( $credentials );
+
+        $response = $this->prompt(
+            prompt: $userPrompt,
+            provider: $credentials->provider,
+            model: $model,
+        );
+
+        if ( ! $response instanceof StructuredAgentResponse ) {
+            throw new RuntimeException( sprintf(
+                'Expected a StructuredAgentResponse from provider [%s] for model [%s]; got %s.',
+                $credentials->provider,
+                $model,
+                get_debug_type( $response ),
+            ) );
+        }
+
+        return [
+            'output'        => $this->unwrapStructured( $response->structured ),
+            'input_tokens'  => $response->usage->promptTokens,
+            'output_tokens' => $response->usage->completionTokens,
+        ];
+    }
+
+    /**
+     * Unwrap a single-key envelope that some models (notably Anthropic's
+     * Opus family) add around structured tool call arguments — e.g.
+     * `{"$PARAMETER_NAME": {actual}}` or `{"data": {actual}}` — when they
+     * treat the tool's `input_schema` as an outer container rather than
+     * the payload itself.
+     *
+     * Only unwraps when:
+     *   - the outer structure is a single-key associative array
+     *   - the single value is an array that shares at least one required
+     *     top-level key with {@see outputSchema()}
+     *
+     * Multi-key responses (the normal case) pass through untouched.
+     *
+     * @param  array<string, mixed>  $structured
+     *
+     * @return array<string, mixed>
+     */
+    protected function unwrapStructured( array $structured ): array
+    {
+        if ( 1 !== count( $structured ) ) {
+            return $structured;
+        }
+
+        $inner = reset( $structured );
+
+        if ( ! is_array( $inner ) ) {
+            return $structured;
+        }
+
+        $expectedRequired = $this->outputSchema()['required'] ?? [];
+
+        if ( ! is_array( $expectedRequired ) || [] === $expectedRequired ) {
+            return $structured;
+        }
+
+        // If the outer key is already one of the required top-level fields,
+        // don't unwrap — that would strip a valid single-required-field
+        // response.
+        $outerKey = array_key_first( $structured );
+
+        if ( in_array( $outerKey, $expectedRequired, true ) ) {
+            return $structured;
+        }
+
+        $overlap = array_intersect( $expectedRequired, array_keys( $inner ) );
+
+        return count( $overlap ) > 0 ? $inner : $structured;
+    }
+
+    /**
+     * Push the resolved credentials into `laravel/ai`'s runtime config so
+     * the manager wires the right API key / base URL when the driver spins
+     * up. Idempotent within a request.
+     */
+    protected function configureProvider( Credentials $credentials ): void
+    {
+        $providerKey = 'ai.providers.' . $credentials->provider;
+
+        config()->set( $providerKey . '.key', $credentials->apiKey );
+
+        if ( null !== $credentials->baseUrl && '' !== $credentials->baseUrl ) {
+            config()->set( $providerKey . '.url', $credentials->baseUrl );
+        }
+    }
+}

--- a/src/AI/Concerns/CallsLaravelAi.php
+++ b/src/AI/Concerns/CallsLaravelAi.php
@@ -16,6 +16,9 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\SecurityAnalytics\AI\Concerns;
 
 use ArtisanPackUI\Ai\Credentials\Credentials;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Laravel\Ai\Ai;
+use Laravel\Ai\ObjectSchema;
 use Laravel\Ai\Promptable;
 use Laravel\Ai\Responses\StructuredAgentResponse;
 use RuntimeException;
@@ -39,32 +42,75 @@ trait CallsLaravelAi
     use Promptable;
 
     /**
+     * Resolved instructions the base pipeline computed for this run.
+     *
+     * Populated by {@see promptStructured()} for the duration of a single
+     * `execute()` call and consulted by the subclass's `instructions()`
+     * override. `laravel/ai` calls `$agent->instructions()` directly on the
+     * agent (see `Providers\Concerns\GeneratesText.php`), so any settings-
+     * or config-layer override must land in the return value of that method
+     * — not just on the `execute()` argument.
+     *
+     * @since 1.1.0
+     */
+    protected ?string $currentInstructions = null;
+
+    /**
+     * Materialize the fluent schema into the array-shaped representation
+     * the base {@see ArtisanPackAgent::outputSchema()} contract expects.
+     *
+     * Single source of truth: subclasses implement `schema()` only; the
+     * required-keys derivation for {@see unwrapStructured()} and any
+     * consumer that wants the plain JSON Schema flow through here.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, mixed>
+     */
+    public function outputSchema(): array
+    {
+        return ( new ObjectSchema( $this->schema( new JsonSchemaTypeFactory() ) ) )->toSchema();
+    }
+
+    /**
      * Invoke `laravel/ai` and unpack the structured response into the
      * envelope the {@see ArtisanPackAgent::run()} pipeline expects.
      *
      * The credentials passed here come from the base pipeline's resolver
      * chain — they're pushed into the `ai.providers.{provider}` config
-     * slot so `laravel/ai`'s manager resolves against the right key /
-     * base URL. This is scoped to the current request and safe to repeat.
+     * slot and the manager's cached provider is invalidated so the next
+     * resolution rebuilds against the right key / base URL. Scoped to the
+     * current invocation via try/finally.
      *
-     * @param  Credentials  $credentials  Resolved provider credentials.
-     * @param  string       $model        Resolved model identifier.
-     * @param  string       $userPrompt   The user-role prompt body.
+     * @param  Credentials  $credentials   Resolved provider credentials.
+     * @param  string       $model         Resolved model identifier.
+     * @param  string       $instructions  Resolved system prompt (may layer over the class default).
+     * @param  string       $userPrompt    The user-role prompt body.
      *
      * @return array{ output: array<string, mixed>, input_tokens: int, output_tokens: int }
      */
     protected function promptStructured(
         Credentials $credentials,
         string $model,
+        string $instructions,
         string $userPrompt,
     ): array {
         $this->configureProvider( $credentials );
 
-        $response = $this->prompt(
-            prompt: $userPrompt,
-            provider: $credentials->provider,
-            model: $model,
-        );
+        // Store the resolved instructions so the subclass's overridden
+        // `instructions()` method returns them when `laravel/ai` reads them
+        // off the agent. Guarded by try/finally so no leakage between runs.
+        $this->currentInstructions = $instructions;
+
+        try {
+            $response = $this->prompt(
+                prompt: $userPrompt,
+                provider: $credentials->provider,
+                model: $model,
+            );
+        } finally {
+            $this->currentInstructions = null;
+        }
 
         if ( ! $response instanceof StructuredAgentResponse ) {
             throw new RuntimeException( sprintf(
@@ -89,12 +135,15 @@ trait CallsLaravelAi
      * treat the tool's `input_schema` as an outer container rather than
      * the payload itself.
      *
-     * Only unwraps when:
-     *   - the outer structure is a single-key associative array
-     *   - the single value is an array that shares at least one required
-     *     top-level key with {@see outputSchema()}
-     *
-     * Multi-key responses (the normal case) pass through untouched.
+     * Only unwraps when the outer structure is a single-key associative
+     * array whose value is an array that shares at least one required
+     * top-level key with {@see outputSchema()}. That intersection check
+     * is sufficient: a correctly-shaped flat response like
+     * `{"only_required_key": [...list...]}` has integer keys inside the
+     * list, so the intersection is empty and the response passes through
+     * untouched. A double-wrap under the same required key like
+     * `{"only_required_key": {"only_required_key": [...list...]}}` has a
+     * string-keyed inner map that DOES intersect, so we unwrap.
      *
      * @param  array<string, mixed>  $structured
      *
@@ -118,15 +167,6 @@ trait CallsLaravelAi
             return $structured;
         }
 
-        // If the outer key is already one of the required top-level fields,
-        // don't unwrap — that would strip a valid single-required-field
-        // response.
-        $outerKey = array_key_first( $structured );
-
-        if ( in_array( $outerKey, $expectedRequired, true ) ) {
-            return $structured;
-        }
-
         $overlap = array_intersect( $expectedRequired, array_keys( $inner ) );
 
         return count( $overlap ) > 0 ? $inner : $structured;
@@ -135,16 +175,38 @@ trait CallsLaravelAi
     /**
      * Push the resolved credentials into `laravel/ai`'s runtime config so
      * the manager wires the right API key / base URL when the driver spins
-     * up. Idempotent within a request.
+     * up, then invalidate any cached provider instance so the next
+     * resolution rebuilds against the new config.
+     *
+     * `laravel/ai`'s `AiManager` extends `MultipleInstanceManager`, which
+     * caches resolved providers in `$this->instances[$name]`, and
+     * `Provider::__construct` snapshots the config array by value. Without
+     * the `forgetInstance()` call, a second agent's credentials would be
+     * silently ignored — the first key seen by the process would be reused
+     * for every subsequent call.
+     *
+     * Also read-modify-writes existing per-provider config so `.driver`
+     * and other fields set by the host app's `config/ai.php` are preserved.
      */
     protected function configureProvider( Credentials $credentials ): void
     {
         $providerKey = 'ai.providers.' . $credentials->provider;
+        $existing    = (array) config( $providerKey, [] );
 
-        config()->set( $providerKey . '.key', $credentials->apiKey );
+        $existing['key'] = $credentials->apiKey;
 
         if ( null !== $credentials->baseUrl && '' !== $credentials->baseUrl ) {
-            config()->set( $providerKey . '.url', $credentials->baseUrl );
+            $existing['url'] = $credentials->baseUrl;
         }
+
+        // Preserve the driver slug if the host app hasn't defined a config
+        // block yet — the manager needs a `.driver` key to resolve.
+        if ( ! isset( $existing['driver'] ) ) {
+            $existing['driver'] = $credentials->provider;
+        }
+
+        config()->set( $providerKey, $existing );
+
+        Ai::forgetInstance( $credentials->provider );
     }
 }

--- a/src/Livewire/AnomalySummaryPanel.php
+++ b/src/Livewire/AnomalySummaryPanel.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * AnomalySummaryPanel Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAnalytics\Livewire;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\AnomalySummaryAgent;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger surface for the {@see AnomalySummaryAgent}.
+ *
+ * Rendered on the security dashboard. The user picks a window (in hours),
+ * clicks generate, and gets back a scannable digest. Disabled when the
+ * `security.anomaly_summary` feature is off or credentials are missing.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @since      1.1.0
+ */
+class AnomalySummaryPanel extends Component
+{
+    /**
+     * Window in hours the digest covers.
+     */
+    public int $windowHours = 24;
+
+    /**
+     * Whether the underlying feature is available.
+     */
+    public bool $available = false;
+
+    /**
+     * Whether the toggle is on (independent of credentials).
+     */
+    public bool $toggleOn = false;
+
+    /**
+     * The last summary result, or null before it has run.
+     *
+     * @var array<string, mixed>|null
+     */
+    public ?array $result = null;
+
+    /**
+     * Human-readable error message when the last summary failed.
+     */
+    public ?string $error = null;
+
+    public function mount(): void
+    {
+        if ( ! auth()->user()?->can( 'view-security-dashboard' ) ) {
+            abort( 403, 'Unauthorized to view anomaly summary.' );
+        }
+
+        $registry = app( FeatureRegistry::class );
+
+        $this->toggleOn  = $registry->isToggleOn( 'security.anomaly_summary' );
+        $this->available = $registry->isEnabled( 'security.anomaly_summary' );
+    }
+
+    public function generate(): void
+    {
+        if ( ! auth()->user()?->can( 'view-security-dashboard' ) ) {
+            abort( 403, 'Unauthorized to generate anomaly summary.' );
+        }
+
+        $this->result = null;
+        $this->error  = null;
+
+        if ( $this->windowHours < 1 || $this->windowHours > 720 ) {
+            $this->error = __( 'Window must be between 1 and 720 hours.' );
+
+            return;
+        }
+
+        try {
+            $this->result = AnomalySummaryAgent::for( $this->windowHours )->run();
+        } catch ( FeatureDisabledException $e ) {
+            $this->available = false;
+            $this->toggleOn  = false;
+            $this->error     = __( 'Anomaly summary is turned off for this environment.' );
+        } catch ( MissingCredentialsException $e ) {
+            $this->available = false;
+            $this->error     = __( 'AI credentials are not configured for anomaly summary.' );
+        } catch ( Throwable $e ) {
+            $this->error = __( 'Anomaly summary failed: :message', [ 'message' => $e->getMessage() ] );
+        }
+    }
+
+    public function render()
+    {
+        return view( 'security-analytics::livewire.anomaly-summary-panel' );
+    }
+}

--- a/src/Livewire/AnomalySummaryPanel.php
+++ b/src/Livewire/AnomalySummaryPanel.php
@@ -19,6 +19,8 @@ use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
 use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
 use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
 use ArtisanPackUI\SecurityAnalytics\AI\Agents\AnomalySummaryAgent;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 use Throwable;
 
@@ -28,6 +30,9 @@ use Throwable;
  * Rendered on the security dashboard. The user picks a window (in hours),
  * clicks generate, and gets back a scannable digest. Disabled when the
  * `security.anomaly_summary` feature is off or credentials are missing.
+ *
+ * `$windowHours` is intentionally client-writable (the input field binds
+ * to it) but bounded by the `generate()` action to `[1, 720]`.
  *
  * @package    ArtisanPack_UI
  * @subpackage SecurityAnalytics
@@ -63,10 +68,15 @@ class AnomalySummaryPanel extends Component
      */
     public ?string $error = null;
 
+    /**
+     * Mount the panel and probe the feature-registry state.
+     *
+     * @since 1.1.0
+     */
     public function mount(): void
     {
         if ( ! auth()->user()?->can( 'view-security-dashboard' ) ) {
-            abort( 403, 'Unauthorized to view anomaly summary.' );
+            abort( 403, __( 'Unauthorized to view anomaly summary.' ) );
         }
 
         $registry = app( FeatureRegistry::class );
@@ -75,10 +85,15 @@ class AnomalySummaryPanel extends Component
         $this->available = $registry->isEnabled( 'security.anomaly_summary' );
     }
 
+    /**
+     * Generate the digest for the current window.
+     *
+     * @since 1.1.0
+     */
     public function generate(): void
     {
         if ( ! auth()->user()?->can( 'view-security-dashboard' ) ) {
-            abort( 403, 'Unauthorized to generate anomaly summary.' );
+            abort( 403, __( 'Unauthorized to generate anomaly summary.' ) );
         }
 
         $this->result = null;
@@ -100,11 +115,25 @@ class AnomalySummaryPanel extends Component
             $this->available = false;
             $this->error     = __( 'AI credentials are not configured for anomaly summary.' );
         } catch ( Throwable $e ) {
-            $this->error = __( 'Anomaly summary failed: :message', [ 'message' => $e->getMessage() ] );
+            // Log the raw exception (which may contain the upstream URL or
+            // even API-key headers) server-side; surface a redacted generic
+            // message in the browser DOM.
+            Log::error( 'AnomalySummaryAgent invocation failed', [
+                'window_hours' => $this->windowHours,
+                'error'        => $e->getMessage(),
+                'class'        => $e::class,
+            ] );
+
+            $this->error = __( 'Anomaly summary failed. Check the server logs for details.' );
         }
     }
 
-    public function render()
+    /**
+     * Render the panel view.
+     *
+     * @since 1.1.0
+     */
+    public function render(): View
     {
         return view( 'security-analytics::livewire.anomaly-summary-panel' );
     }

--- a/src/Livewire/IncidentResponsePanel.php
+++ b/src/Livewire/IncidentResponsePanel.php
@@ -20,6 +20,9 @@ use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
 use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
 use ArtisanPackUI\SecurityAnalytics\AI\Agents\IncidentResponseAgent;
 use ArtisanPackUI\SecurityAnalytics\Models\SecurityIncident;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Log;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Throwable;
 
@@ -38,8 +41,13 @@ use Throwable;
 class IncidentResponsePanel extends Component
 {
     /**
-     * ID of the {@see SecurityIncident} to advise on.
+     * ID of the {@see SecurityIncident} to advise on. `#[Locked]` because
+     * Livewire 3 hydrates public properties from the client on every
+     * request; without this, a user with the coarse
+     * `view-security-events` capability could rewire the target to any
+     * incident id via the wire protocol.
      */
+    #[Locked]
     public ?int $incidentId = null;
 
     /**
@@ -64,10 +72,15 @@ class IncidentResponsePanel extends Component
      */
     public ?string $error = null;
 
+    /**
+     * Mount the panel and probe the feature-registry state.
+     *
+     * @since 1.1.0
+     */
     public function mount( ?int $incidentId = null ): void
     {
         if ( ! auth()->user()?->can( 'view-security-events' ) ) {
-            abort( 403, 'Unauthorized to view incident response suggestions.' );
+            abort( 403, __( 'Unauthorized to view incident response suggestions.' ) );
         }
 
         $this->incidentId = $incidentId;
@@ -78,10 +91,15 @@ class IncidentResponsePanel extends Component
         $this->available = $registry->isEnabled( 'security.incident_response' );
     }
 
+    /**
+     * Run the incident-response agent against `$this->incidentId`.
+     *
+     * @since 1.1.0
+     */
     public function suggest(): void
     {
         if ( ! auth()->user()?->can( 'view-security-events' ) ) {
-            abort( 403, 'Unauthorized to trigger incident response suggestions.' );
+            abort( 403, __( 'Unauthorized to trigger incident response suggestions.' ) );
         }
 
         $this->result = null;
@@ -103,11 +121,25 @@ class IncidentResponsePanel extends Component
             $this->available = false;
             $this->error     = __( 'AI credentials are not configured for incident response.' );
         } catch ( Throwable $e ) {
-            $this->error = __( 'Incident response suggestions failed: :message', [ 'message' => $e->getMessage() ] );
+            // Log the raw exception (which may contain the upstream URL or
+            // even API-key headers) server-side; surface a redacted generic
+            // message in the browser DOM.
+            Log::error( 'IncidentResponseAgent invocation failed', [
+                'incident_id' => $this->incidentId,
+                'error'       => $e->getMessage(),
+                'class'       => $e::class,
+            ] );
+
+            $this->error = __( 'Incident response suggestions failed. Check the server logs for details.' );
         }
     }
 
-    public function render()
+    /**
+     * Render the panel view.
+     *
+     * @since 1.1.0
+     */
+    public function render(): View
     {
         return view( 'security-analytics::livewire.incident-response-panel' );
     }

--- a/src/Livewire/IncidentResponsePanel.php
+++ b/src/Livewire/IncidentResponsePanel.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * IncidentResponsePanel Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAnalytics\Livewire;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\IncidentResponseAgent;
+use ArtisanPackUI\SecurityAnalytics\Models\SecurityIncident;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger surface for the {@see IncidentResponseAgent}.
+ *
+ * Rendered on the incident detail page. Suggestion-only — never triggers
+ * an action; the responder decides. Disabled state when the
+ * `security.incident_response` feature is off or credentials are missing.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @since      1.1.0
+ */
+class IncidentResponsePanel extends Component
+{
+    /**
+     * ID of the {@see SecurityIncident} to advise on.
+     */
+    public ?int $incidentId = null;
+
+    /**
+     * Whether the underlying feature is available.
+     */
+    public bool $available = false;
+
+    /**
+     * Whether the toggle is on (independent of credentials).
+     */
+    public bool $toggleOn = false;
+
+    /**
+     * The last suggestion result, or null before it has run.
+     *
+     * @var array<string, mixed>|null
+     */
+    public ?array $result = null;
+
+    /**
+     * Human-readable error message when the last suggestion failed.
+     */
+    public ?string $error = null;
+
+    public function mount( ?int $incidentId = null ): void
+    {
+        if ( ! auth()->user()?->can( 'view-security-events' ) ) {
+            abort( 403, 'Unauthorized to view incident response suggestions.' );
+        }
+
+        $this->incidentId = $incidentId;
+
+        $registry = app( FeatureRegistry::class );
+
+        $this->toggleOn  = $registry->isToggleOn( 'security.incident_response' );
+        $this->available = $registry->isEnabled( 'security.incident_response' );
+    }
+
+    public function suggest(): void
+    {
+        if ( ! auth()->user()?->can( 'view-security-events' ) ) {
+            abort( 403, 'Unauthorized to trigger incident response suggestions.' );
+        }
+
+        $this->result = null;
+        $this->error  = null;
+
+        if ( null === $this->incidentId ) {
+            $this->error = __( 'Select an incident to advise on.' );
+
+            return;
+        }
+
+        try {
+            $this->result = IncidentResponseAgent::for( $this->incidentId )->run();
+        } catch ( FeatureDisabledException $e ) {
+            $this->available = false;
+            $this->toggleOn  = false;
+            $this->error     = __( 'Incident response suggestions are turned off for this environment.' );
+        } catch ( MissingCredentialsException $e ) {
+            $this->available = false;
+            $this->error     = __( 'AI credentials are not configured for incident response.' );
+        } catch ( Throwable $e ) {
+            $this->error = __( 'Incident response suggestions failed: :message', [ 'message' => $e->getMessage() ] );
+        }
+    }
+
+    public function render()
+    {
+        return view( 'security-analytics::livewire.incident-response-panel' );
+    }
+}

--- a/src/Livewire/ThreatTriagePanel.php
+++ b/src/Livewire/ThreatTriagePanel.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * ThreatTriagePanel Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAnalytics\Livewire;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\ThreatTriageAgent;
+use ArtisanPackUI\SecurityAnalytics\Models\SecurityEvent;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger surface for the {@see ThreatTriageAgent}.
+ *
+ * Rendered inline on the security-event detail surface. When the
+ * `security.threat_triage` feature is disabled or unavailable the component
+ * renders a disabled state; no agent call happens and no cost is incurred.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAnalytics
+ *
+ * @since      1.1.0
+ */
+class ThreatTriagePanel extends Component
+{
+    /**
+     * ID of the {@see SecurityEvent} to triage.
+     */
+    public ?int $eventId = null;
+
+    /**
+     * Whether the underlying feature is available (toggle on and credentials
+     * resolvable).
+     */
+    public bool $available = false;
+
+    /**
+     * Whether the toggle is on (independent of credentials).
+     */
+    public bool $toggleOn = false;
+
+    /**
+     * The last triage result, or null before triage has run.
+     *
+     * @var array<string, mixed>|null
+     */
+    public ?array $result = null;
+
+    /**
+     * Human-readable error message when the last triage failed.
+     */
+    public ?string $error = null;
+
+    public function mount( ?int $eventId = null ): void
+    {
+        if ( ! auth()->user()?->can( 'view-security-events' ) ) {
+            abort( 403, 'Unauthorized to view threat triage.' );
+        }
+
+        $this->eventId = $eventId;
+
+        $registry = app( FeatureRegistry::class );
+
+        $this->toggleOn  = $registry->isToggleOn( 'security.threat_triage' );
+        $this->available = $registry->isEnabled( 'security.threat_triage' );
+    }
+
+    public function triage(): void
+    {
+        if ( ! auth()->user()?->can( 'view-security-events' ) ) {
+            abort( 403, 'Unauthorized to trigger threat triage.' );
+        }
+
+        $this->result = null;
+        $this->error  = null;
+
+        if ( null === $this->eventId ) {
+            $this->error = __( 'Select a security event to triage.' );
+
+            return;
+        }
+
+        try {
+            $this->result = ThreatTriageAgent::for( $this->eventId )->run();
+        } catch ( FeatureDisabledException $e ) {
+            $this->available = false;
+            $this->toggleOn  = false;
+            $this->error     = __( 'Threat triage is turned off for this environment.' );
+        } catch ( MissingCredentialsException $e ) {
+            $this->available = false;
+            $this->error     = __( 'AI credentials are not configured for threat triage.' );
+        } catch ( Throwable $e ) {
+            $this->error = __( 'Threat triage failed: :message', [ 'message' => $e->getMessage() ] );
+        }
+    }
+
+    public function render()
+    {
+        return view( 'security-analytics::livewire.threat-triage-panel' );
+    }
+}

--- a/src/Livewire/ThreatTriagePanel.php
+++ b/src/Livewire/ThreatTriagePanel.php
@@ -20,6 +20,9 @@ use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
 use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
 use ArtisanPackUI\SecurityAnalytics\AI\Agents\ThreatTriageAgent;
 use ArtisanPackUI\SecurityAnalytics\Models\SecurityEvent;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Log;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Throwable;
 
@@ -38,8 +41,13 @@ use Throwable;
 class ThreatTriagePanel extends Component
 {
     /**
-     * ID of the {@see SecurityEvent} to triage.
+     * ID of the {@see SecurityEvent} to triage. `#[Locked]` because
+     * Livewire 3 hydrates public properties from the client on every
+     * request; without this, a user with the coarse
+     * `view-security-events` capability could rewire the target to any
+     * event id via the wire protocol.
      */
+    #[Locked]
     public ?int $eventId = null;
 
     /**
@@ -65,10 +73,15 @@ class ThreatTriagePanel extends Component
      */
     public ?string $error = null;
 
+    /**
+     * Mount the component and probe the feature-registry state.
+     *
+     * @since 1.1.0
+     */
     public function mount( ?int $eventId = null ): void
     {
         if ( ! auth()->user()?->can( 'view-security-events' ) ) {
-            abort( 403, 'Unauthorized to view threat triage.' );
+            abort( 403, __( 'Unauthorized to view threat triage.' ) );
         }
 
         $this->eventId = $eventId;
@@ -79,10 +92,15 @@ class ThreatTriagePanel extends Component
         $this->available = $registry->isEnabled( 'security.threat_triage' );
     }
 
+    /**
+     * Run the triage agent against `$this->eventId`.
+     *
+     * @since 1.1.0
+     */
     public function triage(): void
     {
         if ( ! auth()->user()?->can( 'view-security-events' ) ) {
-            abort( 403, 'Unauthorized to trigger threat triage.' );
+            abort( 403, __( 'Unauthorized to trigger threat triage.' ) );
         }
 
         $this->result = null;
@@ -104,11 +122,25 @@ class ThreatTriagePanel extends Component
             $this->available = false;
             $this->error     = __( 'AI credentials are not configured for threat triage.' );
         } catch ( Throwable $e ) {
-            $this->error = __( 'Threat triage failed: :message', [ 'message' => $e->getMessage() ] );
+            // Log the raw exception (which may contain the upstream URL or
+            // even API-key headers) server-side; surface a redacted generic
+            // message in the browser DOM.
+            Log::error( 'ThreatTriageAgent invocation failed', [
+                'event_id' => $this->eventId,
+                'error'    => $e->getMessage(),
+                'class'    => $e::class,
+            ] );
+
+            $this->error = __( 'Threat triage failed. Check the server logs for details.' );
         }
     }
 
-    public function render()
+    /**
+     * Render the panel view.
+     *
+     * @since 1.1.0
+     */
+    public function render(): View
     {
         return view( 'security-analytics::livewire.threat-triage-panel' );
     }

--- a/src/SecurityAnalyticsServiceProvider.php
+++ b/src/SecurityAnalyticsServiceProvider.php
@@ -15,6 +15,9 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAnalytics;
 
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\AnomalySummaryAgent;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\IncidentResponseAgent;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\ThreatTriageAgent;
 use ArtisanPackUI\SecurityAnalytics\Analytics\Alerting\AlertManager;
 use ArtisanPackUI\SecurityAnalytics\Analytics\Alerting\Channels\DatabaseChannel;
 use ArtisanPackUI\SecurityAnalytics\Analytics\Alerting\Channels\OpsGenieChannel;
@@ -133,6 +136,43 @@ class SecurityAnalyticsServiceProvider extends ServiceProvider
                 UpdateBehaviorBaselinesCommand::class,
             ] );
         }
+    }
+
+    /**
+     * AI features contributed by this package.
+     *
+     * Discovered by `artisanpack-ui/ai`'s auto-registration pass in the
+     * `AiServiceProvider::boot()` cycle, which walks every registered
+     * service provider looking for this method. Feature keys map to an
+     * agent class + metadata; each entry is toggleable at runtime via the
+     * feature registry.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function aiFeatures(): array
+    {
+        return [
+            'security.threat_triage' => [
+                'agent'       => ThreatTriageAgent::class,
+                'package'     => 'artisanpack-ui/security-analytics',
+                'label'       => 'Threat triage',
+                'description' => 'Plain-language severity and recommended actions for a security event.',
+            ],
+            'security.anomaly_summary' => [
+                'agent'       => AnomalySummaryAgent::class,
+                'package'     => 'artisanpack-ui/security-analytics',
+                'label'       => 'Anomaly summary',
+                'description' => 'Periodic digest of unusual security events for out-of-band stakeholders.',
+            ],
+            'security.incident_response' => [
+                'agent'       => IncidentResponseAgent::class,
+                'package'     => 'artisanpack-ui/security-analytics',
+                'label'       => 'Incident response',
+                'description' => 'Suggested next steps for an open incident. Advisory only — never triggers actions.',
+            ],
+        ];
     }
 
     /**

--- a/src/SecurityAnalyticsServiceProvider.php
+++ b/src/SecurityAnalyticsServiceProvider.php
@@ -60,8 +60,12 @@ use ArtisanPackUI\SecurityAnalytics\Console\Commands\SyncThreatFeedsCommand;
 use ArtisanPackUI\SecurityAnalytics\Console\Commands\TestSiemConnectionCommand;
 use ArtisanPackUI\SecurityAnalytics\Console\Commands\UpdateBehaviorBaselinesCommand;
 use ArtisanPackUI\SecurityAnalytics\Contracts\SecurityEventLoggerInterface;
+use ArtisanPackUI\SecurityAnalytics\Livewire\AnomalySummaryPanel;
+use ArtisanPackUI\SecurityAnalytics\Livewire\IncidentResponsePanel;
+use ArtisanPackUI\SecurityAnalytics\Livewire\ThreatTriagePanel;
 use ArtisanPackUI\SecurityAnalytics\Services\SecurityEventLogger;
 use Illuminate\Support\ServiceProvider;
+use Livewire\Livewire;
 
 /**
  * Service provider for the Security Analytics package.
@@ -121,6 +125,8 @@ class SecurityAnalyticsServiceProvider extends ServiceProvider
         // routes file itself short-circuits when the dashboard is disabled.
         $this->loadRoutesFrom( __DIR__ . '/../routes/dashboard.php' );
 
+        $this->registerAiLivewireComponents();
+
         if ( $this->app->runningInConsole() ) {
             $this->commands( [
                 AnalyticsProcessCommand::class,
@@ -173,6 +179,28 @@ class SecurityAnalyticsServiceProvider extends ServiceProvider
                 'description' => 'Suggested next steps for an open incident. Advisory only — never triggers actions.',
             ],
         ];
+    }
+
+    /**
+     * Register the three AI trigger Livewire components under short tag
+     * names so consumers can drop them into a Blade view without the full
+     * FQCN. Skipped when livewire/livewire isn't installed.
+     *
+     * @since 1.1.0
+     */
+    protected function registerAiLivewireComponents(): void
+    {
+        // Guard on the concrete container binding — `class_exists()` on the
+        // Livewire facade is true even for unit tests that don't boot the
+        // Livewire provider, and calling `Livewire::component()` in that
+        // window resolves `livewire.finder` and blows up.
+        if ( ! class_exists( Livewire::class ) || ! $this->app->bound( 'livewire' ) ) {
+            return;
+        }
+
+        Livewire::component( 'threat-triage-panel', ThreatTriagePanel::class );
+        Livewire::component( 'anomaly-summary-panel', AnomalySummaryPanel::class );
+        Livewire::component( 'incident-response-panel', IncidentResponsePanel::class );
     }
 
     /**

--- a/src/SecurityAnalyticsServiceProvider.php
+++ b/src/SecurityAnalyticsServiceProvider.php
@@ -163,20 +163,20 @@ class SecurityAnalyticsServiceProvider extends ServiceProvider
             'security.threat_triage' => [
                 'agent'       => ThreatTriageAgent::class,
                 'package'     => 'artisanpack-ui/security-analytics',
-                'label'       => 'Threat triage',
-                'description' => 'Plain-language severity and recommended actions for a security event.',
+                'label'       => __( 'Threat triage' ),
+                'description' => __( 'Plain-language severity and recommended actions for a security event.' ),
             ],
             'security.anomaly_summary' => [
                 'agent'       => AnomalySummaryAgent::class,
                 'package'     => 'artisanpack-ui/security-analytics',
-                'label'       => 'Anomaly summary',
-                'description' => 'Periodic digest of unusual security events for out-of-band stakeholders.',
+                'label'       => __( 'Anomaly summary' ),
+                'description' => __( 'Periodic digest of unusual security events for out-of-band stakeholders.' ),
             ],
             'security.incident_response' => [
                 'agent'       => IncidentResponseAgent::class,
                 'package'     => 'artisanpack-ui/security-analytics',
-                'label'       => 'Incident response',
-                'description' => 'Suggested next steps for an open incident. Advisory only — never triggers actions.',
+                'label'       => __( 'Incident response' ),
+                'description' => __( 'Suggested next steps for an open incident. Advisory only — never triggers actions.' ),
             ],
         ];
     }
@@ -198,9 +198,9 @@ class SecurityAnalyticsServiceProvider extends ServiceProvider
             return;
         }
 
-        Livewire::component( 'threat-triage-panel', ThreatTriagePanel::class );
-        Livewire::component( 'anomaly-summary-panel', AnomalySummaryPanel::class );
-        Livewire::component( 'incident-response-panel', IncidentResponsePanel::class );
+        Livewire::component( 'security-analytics.threat-triage-panel', ThreatTriagePanel::class );
+        Livewire::component( 'security-analytics.anomaly-summary-panel', AnomalySummaryPanel::class );
+        Livewire::component( 'security-analytics.incident-response-panel', IncidentResponsePanel::class );
     }
 
     /**

--- a/tests/Feature/AI/Agents/AnomalySummaryAgentTest.php
+++ b/tests/Feature/AI/Agents/AnomalySummaryAgentTest.php
@@ -22,6 +22,8 @@ beforeEach( function (): void {
         defaultModel: 'claude-haiku-4-5-20251001',
     ) );
     $resolver->useStore( fn () => null );
+
+    AnomalySummaryAgent::fake( [] );
 } );
 
 it( 'declares the security.anomaly_summary feature key', function (): void {
@@ -65,9 +67,15 @@ it( 'runs end-to-end for a window and returns a schema-shaped payload', function
 it( 'handles an empty window gracefully', function (): void {
     $result = AnomalySummaryAgent::for( 24 )->run();
 
-    expect( $result['headline'] )->toContain( 'No anomalies' );
-    expect( $result['top_severities'] )->toBe( [] );
-    expect( $result['top_detectors'] )->toBe( [] );
+    expect( $result )->toHaveKeys( [
+        'headline',
+        'body',
+        'top_severities',
+        'top_detectors',
+        'recommended_followups',
+    ] );
+    expect( $result['top_severities'] )->toBeArray();
+    expect( $result['top_detectors'] )->toBeArray();
 } );
 
 it( 'accepts a pre-built payload array', function (): void {

--- a/tests/Feature/AI/Agents/AnomalySummaryAgentTest.php
+++ b/tests/Feature/AI/Agents/AnomalySummaryAgentTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\AnomalySummaryAgent;
+use ArtisanPackUI\SecurityAnalytics\Models\Anomaly;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    /** @var ChainedCredentialResolver $resolver */
+    $resolver = app( CredentialResolver::class );
+    $resolver->setOverride( new Credentials(
+        provider: 'anthropic',
+        apiKey: 'sk-test',
+        defaultModel: 'claude-haiku-4-5-20251001',
+    ) );
+    $resolver->useStore( fn () => null );
+} );
+
+it( 'declares the security.anomaly_summary feature key', function (): void {
+    $agent = new AnomalySummaryAgent();
+
+    expect( $agent->featureKey )->toBe( 'security.anomaly_summary' );
+    expect( $agent->package )->toBe( 'artisanpack-ui/security-analytics' );
+} );
+
+it( 'declares an output schema with the five required keys', function (): void {
+    $schema = ( new AnomalySummaryAgent() )->outputSchema();
+
+    expect( $schema['required'] )->toBe( [
+        'headline',
+        'body',
+        'top_severities',
+        'top_detectors',
+        'recommended_followups',
+    ] );
+} );
+
+it( 'runs end-to-end for a window and returns a schema-shaped payload', function (): void {
+    Anomaly::factory()->count( 3 )->create( [
+        'detected_at' => now()->subHours( 2 ),
+    ] );
+
+    $result = AnomalySummaryAgent::for( 24 )->run();
+
+    expect( $result )->toHaveKeys( [
+        'headline',
+        'body',
+        'top_severities',
+        'top_detectors',
+        'recommended_followups',
+    ] );
+    expect( $result['headline'] )->toBeString();
+    expect( $result['body'] )->toBeString();
+    expect( $result['top_severities'] )->toBeArray();
+} );
+
+it( 'handles an empty window gracefully', function (): void {
+    $result = AnomalySummaryAgent::for( 24 )->run();
+
+    expect( $result['headline'] )->toContain( 'No anomalies' );
+    expect( $result['top_severities'] )->toBe( [] );
+    expect( $result['top_detectors'] )->toBe( [] );
+} );
+
+it( 'accepts a pre-built payload array', function (): void {
+    $result = AnomalySummaryAgent::for( [
+        'window_hours' => 48,
+        'anomalies'    => [],
+        'statistics'   => [
+            'total_count' => 0,
+            'by_severity' => [],
+            'by_detector' => [],
+        ],
+    ] )->run();
+
+    expect( $result['headline'] )->toBeString();
+} );
+
+it( 'throws InvalidArgumentException when window_hours is not an int', function (): void {
+    expect( fn () => AnomalySummaryAgent::for( [
+        'window_hours' => 'twelve',
+        'anomalies'    => [],
+        'statistics'   => [],
+    ] )->run() )->toThrow( InvalidArgumentException::class );
+} );
+
+it( 'throws FeatureDisabledException when the toggle is off', function (): void {
+    /** @var FeatureRegistry $registry */
+    $registry = app( FeatureRegistry::class );
+    $registry->disable( 'security.anomaly_summary' );
+
+    expect( fn () => AnomalySummaryAgent::for( 24 )->run() )
+        ->toThrow( FeatureDisabledException::class );
+} );

--- a/tests/Feature/AI/Agents/IncidentResponseAgentTest.php
+++ b/tests/Feature/AI/Agents/IncidentResponseAgentTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\IncidentResponseAgent;
+use ArtisanPackUI\SecurityAnalytics\Models\SecurityIncident;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    /** @var ChainedCredentialResolver $resolver */
+    $resolver = app( CredentialResolver::class );
+    $resolver->setOverride( new Credentials(
+        provider: 'anthropic',
+        apiKey: 'sk-test',
+        defaultModel: 'claude-opus-4-7',
+    ) );
+    $resolver->useStore( fn () => null );
+} );
+
+it( 'declares the security.incident_response feature key and Opus default', function (): void {
+    $agent = new IncidentResponseAgent();
+
+    expect( $agent->featureKey )->toBe( 'security.incident_response' );
+    expect( $agent->package )->toBe( 'artisanpack-ui/security-analytics' );
+    expect( $agent->defaultModel )->toBe( 'claude-opus-4-7' );
+} );
+
+it( 'declares an output schema with the suggested_next_actions key', function (): void {
+    $schema = ( new IncidentResponseAgent() )->outputSchema();
+
+    expect( $schema['required'] )->toBe( [ 'suggested_next_actions' ] );
+
+    $itemProps = $schema['properties']['suggested_next_actions']['items']['properties'];
+    expect( $itemProps )->toHaveKeys( [ 'step', 'rationale', 'risk' ] );
+    expect( $itemProps['risk']['enum'] )->toBe( [ 'low', 'medium', 'high' ] );
+} );
+
+it( 'runs end-to-end for a SecurityIncident id', function (): void {
+    $incident = SecurityIncident::factory()->create( [
+        'severity' => SecurityIncident::SEVERITY_HIGH,
+        'status'   => SecurityIncident::STATUS_OPEN,
+    ] );
+
+    $result = IncidentResponseAgent::for( $incident->id )->run();
+
+    expect( $result )->toHaveKey( 'suggested_next_actions' );
+    expect( $result['suggested_next_actions'] )->toBeArray();
+} );
+
+it( 'accepts a SecurityIncident model as input', function (): void {
+    $incident = SecurityIncident::factory()->create();
+
+    $result = IncidentResponseAgent::for( $incident )->run();
+
+    expect( $result )->toHaveKey( 'suggested_next_actions' );
+} );
+
+it( 'accepts a pre-serialized array payload', function (): void {
+    $result = IncidentResponseAgent::for( [
+        'incident'  => [ 'id' => 1, 'severity' => 'high', 'status' => 'open' ],
+        'timeline'  => [],
+        'playbooks' => [],
+    ] )->run();
+
+    expect( $result )->toHaveKey( 'suggested_next_actions' );
+} );
+
+it( 'throws InvalidArgumentException for an unknown SecurityIncident id', function (): void {
+    expect( fn () => IncidentResponseAgent::for( 99999 )->run() )
+        ->toThrow( InvalidArgumentException::class );
+} );
+
+it( 'throws FeatureDisabledException when the toggle is off', function (): void {
+    /** @var FeatureRegistry $registry */
+    $registry = app( FeatureRegistry::class );
+    $registry->disable( 'security.incident_response' );
+
+    $incident = SecurityIncident::factory()->create();
+
+    expect( fn () => IncidentResponseAgent::for( $incident->id )->run() )
+        ->toThrow( FeatureDisabledException::class );
+} );

--- a/tests/Feature/AI/Agents/IncidentResponseAgentTest.php
+++ b/tests/Feature/AI/Agents/IncidentResponseAgentTest.php
@@ -22,6 +22,8 @@ beforeEach( function (): void {
         defaultModel: 'claude-opus-4-7',
     ) );
     $resolver->useStore( fn () => null );
+
+    IncidentResponseAgent::fake( [] );
 } );
 
 it( 'declares the security.incident_response feature key and Opus default', function (): void {

--- a/tests/Feature/AI/Agents/ThreatTriageAgentTest.php
+++ b/tests/Feature/AI/Agents/ThreatTriageAgentTest.php
@@ -24,6 +24,11 @@ beforeEach( function (): void {
         defaultModel: 'claude-sonnet-4-6',
     ) );
     $resolver->useStore( fn () => null );
+
+    // Route every LLM call through laravel/ai's fake gateway; with an
+    // empty response list it auto-generates a schema-conformant payload
+    // so we can assert on shape without paying tokens.
+    ThreatTriageAgent::fake( [] );
 } );
 
 it( 'declares the security.threat_triage feature key', function (): void {

--- a/tests/Feature/AI/Agents/ThreatTriageAgentTest.php
+++ b/tests/Feature/AI/Agents/ThreatTriageAgentTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Events\AgentUsageRecorded;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\ThreatTriageAgent;
+use ArtisanPackUI\SecurityAnalytics\Models\SecurityEvent;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    /** @var ChainedCredentialResolver $resolver */
+    $resolver = app( CredentialResolver::class );
+    $resolver->setOverride( new Credentials(
+        provider: 'anthropic',
+        apiKey: 'sk-test',
+        defaultModel: 'claude-sonnet-4-6',
+    ) );
+    $resolver->useStore( fn () => null );
+} );
+
+it( 'declares the security.threat_triage feature key', function (): void {
+    $agent = new ThreatTriageAgent();
+
+    expect( $agent->featureKey )->toBe( 'security.threat_triage' );
+    expect( $agent->package )->toBe( 'artisanpack-ui/security-analytics' );
+    expect( $agent->defaultModel )->toBe( 'claude-sonnet-4-6' );
+} );
+
+it( 'declares an output schema with the four required keys', function (): void {
+    $schema = ( new ThreatTriageAgent() )->outputSchema();
+
+    expect( $schema['type'] )->toBe( 'object' );
+    expect( $schema['required'] )->toBe( [
+        'severity',
+        'summary',
+        'recommended_actions',
+        'related_events',
+    ] );
+    expect( $schema['properties']['severity']['enum'] )->toBe(
+        [ 'info', 'low', 'medium', 'high', 'critical' ],
+    );
+} );
+
+it( 'runs end-to-end for a SecurityEvent id and returns a schema-shaped payload', function (): void {
+    $event = SecurityEvent::create( [
+        'event_type'  => SecurityEvent::TYPE_AUTHENTICATION,
+        'event_name'  => 'login.failed',
+        'severity'    => SecurityEvent::SEVERITY_WARNING,
+        'ip_address'  => '203.0.113.10',
+        'user_id'     => 42,
+        'details'     => [ 'reason' => 'bad_password' ],
+        'fingerprint' => 'fp-abc',
+    ] );
+
+    $result = ThreatTriageAgent::for( $event->id )->run();
+
+    expect( $result )->toHaveKeys( [ 'severity', 'summary', 'recommended_actions', 'related_events' ] );
+    expect( $result['severity'] )->toBeIn( [ 'info', 'low', 'medium', 'high', 'critical' ] );
+    expect( $result['summary'] )->toBeString();
+    expect( $result['recommended_actions'] )->toBeArray();
+    expect( $result['related_events'] )->toBeArray();
+} );
+
+it( 'accepts a SecurityEvent model as input', function (): void {
+    $event = SecurityEvent::create( [
+        'event_type' => SecurityEvent::TYPE_API_ACCESS,
+        'event_name' => 'api.rate_limit',
+        'severity'   => SecurityEvent::SEVERITY_ERROR,
+        'ip_address' => '203.0.113.20',
+    ] );
+
+    $result = ThreatTriageAgent::for( $event )->run();
+
+    expect( $result )->toHaveKey( 'severity' );
+} );
+
+it( 'accepts a pre-serialized array payload', function (): void {
+    $result = ThreatTriageAgent::for( [
+        'event' => [
+            'id'         => 999,
+            'event_name' => 'external.event',
+            'severity'   => 'high',
+        ],
+        'related' => [],
+        'context' => [],
+    ] )->run();
+
+    expect( $result )->toHaveKey( 'severity' );
+} );
+
+it( 'throws InvalidArgumentException for an unknown SecurityEvent id', function (): void {
+    expect( fn () => ThreatTriageAgent::for( 99999 )->run() )
+        ->toThrow( InvalidArgumentException::class );
+} );
+
+it( 'throws FeatureDisabledException when the toggle is off', function (): void {
+    /** @var FeatureRegistry $registry */
+    $registry = app( FeatureRegistry::class );
+    $registry->disable( 'security.threat_triage' );
+
+    $event = SecurityEvent::create( [
+        'event_type' => SecurityEvent::TYPE_AUTHENTICATION,
+        'event_name' => 'login.failed',
+        'severity'   => SecurityEvent::SEVERITY_INFO,
+        'ip_address' => '203.0.113.30',
+    ] );
+
+    expect( fn () => ThreatTriageAgent::for( $event->id )->run() )
+        ->toThrow( FeatureDisabledException::class );
+} );
+
+it( 'dispatches AgentUsageRecorded after a successful run', function (): void {
+    Event::fake( [ AgentUsageRecorded::class ] );
+
+    $event = SecurityEvent::create( [
+        'event_type' => SecurityEvent::TYPE_AUTHENTICATION,
+        'event_name' => 'login.failed',
+        'severity'   => SecurityEvent::SEVERITY_WARNING,
+        'ip_address' => '203.0.113.40',
+    ] );
+
+    ThreatTriageAgent::for( $event->id )->run();
+
+    Event::assertDispatched(
+        AgentUsageRecorded::class,
+        fn ( AgentUsageRecorded $e ) => 'security.threat_triage' === $e->featureKey
+            && 'artisanpack-ui/security-analytics' === $e->package,
+    );
+} );

--- a/tests/Feature/AI/AiFeaturesRegistrationTest.php
+++ b/tests/Feature/AI/AiFeaturesRegistrationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\AnomalySummaryAgent;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\IncidentResponseAgent;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\ThreatTriageAgent;
+use ArtisanPackUI\SecurityAnalytics\SecurityAnalyticsServiceProvider;
+
+it( 'exposes the three AI features via the aiFeatures() method', function (): void {
+    $provider = new SecurityAnalyticsServiceProvider( app() );
+    $features = $provider->aiFeatures();
+
+    expect( $features )->toHaveKeys( [
+        'security.threat_triage',
+        'security.anomaly_summary',
+        'security.incident_response',
+    ] );
+
+    expect( $features['security.threat_triage']['agent'] )->toBe( ThreatTriageAgent::class );
+    expect( $features['security.anomaly_summary']['agent'] )->toBe( AnomalySummaryAgent::class );
+    expect( $features['security.incident_response']['agent'] )->toBe( IncidentResponseAgent::class );
+} );
+
+it( 'registers all three features with the AI feature registry via auto-discovery', function (): void {
+    $registry = app( FeatureRegistry::class );
+
+    expect( $registry->get( 'security.threat_triage' ) )->not->toBeNull();
+    expect( $registry->get( 'security.anomaly_summary' ) )->not->toBeNull();
+    expect( $registry->get( 'security.incident_response' ) )->not->toBeNull();
+} );
+
+it( 'attributes each feature to the security-analytics package', function (): void {
+    $registry = app( FeatureRegistry::class );
+
+    expect( $registry->get( 'security.threat_triage' )->package )
+        ->toBe( 'artisanpack-ui/security-analytics' );
+
+    expect( $registry->get( 'security.anomaly_summary' )->package )
+        ->toBe( 'artisanpack-ui/security-analytics' );
+
+    expect( $registry->get( 'security.incident_response' )->package )
+        ->toBe( 'artisanpack-ui/security-analytics' );
+} );
+
+it( 'has each feature toggled on by default (no persistence layer bound)', function (): void {
+    $registry = app( FeatureRegistry::class );
+
+    expect( $registry->isToggleOn( 'security.threat_triage' ) )->toBeTrue();
+    expect( $registry->isToggleOn( 'security.anomaly_summary' ) )->toBeTrue();
+    expect( $registry->isToggleOn( 'security.incident_response' ) )->toBeTrue();
+} );

--- a/tests/Feature/AI/Livewire/AiPanelsRenderTest.php
+++ b/tests/Feature/AI/Livewire/AiPanelsRenderTest.php
@@ -6,6 +6,9 @@ use ArtisanPackUI\Ai\Contracts\CredentialResolver;
 use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
 use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
 use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\AnomalySummaryAgent;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\IncidentResponseAgent;
+use ArtisanPackUI\SecurityAnalytics\AI\Agents\ThreatTriageAgent;
 use ArtisanPackUI\SecurityAnalytics\Livewire\AnomalySummaryPanel;
 use ArtisanPackUI\SecurityAnalytics\Livewire\IncidentResponsePanel;
 use ArtisanPackUI\SecurityAnalytics\Livewire\ThreatTriagePanel;
@@ -38,6 +41,10 @@ beforeEach( function (): void {
         defaultModel: 'claude-sonnet-4-6',
     ) );
     $resolver->useStore( fn () => null );
+
+    ThreatTriageAgent::fake( [] );
+    AnomalySummaryAgent::fake( [] );
+    IncidentResponseAgent::fake( [] );
 } );
 
 it( 'renders the ThreatTriagePanel', function (): void {

--- a/tests/Feature/AI/Livewire/AiPanelsRenderTest.php
+++ b/tests/Feature/AI/Livewire/AiPanelsRenderTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\SecurityAnalytics\Livewire\AnomalySummaryPanel;
+use ArtisanPackUI\SecurityAnalytics\Livewire\IncidentResponsePanel;
+use ArtisanPackUI\SecurityAnalytics\Livewire\ThreatTriagePanel;
+use ArtisanPackUI\SecurityAnalytics\Models\SecurityEvent;
+use ArtisanPackUI\SecurityAnalytics\Models\SecurityIncident;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    Illuminate\Support\Facades\Gate::before( fn () => true );
+
+    $this->actingAs( new class extends Illuminate\Foundation\Auth\User {
+        public $id = 1;
+
+        protected $guarded = [];
+
+        public function getAuthIdentifier()
+        {
+            return 1;
+        }
+    } );
+
+    /** @var ChainedCredentialResolver $resolver */
+    $resolver = app( CredentialResolver::class );
+    $resolver->setOverride( new Credentials(
+        provider: 'anthropic',
+        apiKey: 'sk-test',
+        defaultModel: 'claude-sonnet-4-6',
+    ) );
+    $resolver->useStore( fn () => null );
+} );
+
+it( 'renders the ThreatTriagePanel', function (): void {
+    Livewire::test( ThreatTriagePanel::class )
+        ->assertStatus( 200 )
+        ->assertSee( 'Threat triage' );
+} );
+
+it( 'renders the AnomalySummaryPanel', function (): void {
+    Livewire::test( AnomalySummaryPanel::class )
+        ->assertStatus( 200 )
+        ->assertSee( 'Anomaly summary' );
+} );
+
+it( 'renders the IncidentResponsePanel', function (): void {
+    Livewire::test( IncidentResponsePanel::class )
+        ->assertStatus( 200 )
+        ->assertSee( 'Incident response suggestions' );
+} );
+
+it( 'marks each panel as available when the feature is enabled and credentials resolve', function (): void {
+    Livewire::test( ThreatTriagePanel::class )
+        ->assertSet( 'available', true )
+        ->assertSet( 'toggleOn', true );
+
+    Livewire::test( AnomalySummaryPanel::class )
+        ->assertSet( 'available', true )
+        ->assertSet( 'toggleOn', true );
+
+    Livewire::test( IncidentResponsePanel::class )
+        ->assertSet( 'available', true )
+        ->assertSet( 'toggleOn', true );
+} );
+
+it( 'marks each panel as unavailable and toggleOn=false when the feature is disabled', function (): void {
+    /** @var FeatureRegistry $registry */
+    $registry = app( FeatureRegistry::class );
+
+    $registry->disable( 'security.threat_triage' );
+    $registry->disable( 'security.anomaly_summary' );
+    $registry->disable( 'security.incident_response' );
+
+    Livewire::test( ThreatTriagePanel::class )
+        ->assertSet( 'available', false )
+        ->assertSet( 'toggleOn', false );
+
+    Livewire::test( AnomalySummaryPanel::class )
+        ->assertSet( 'available', false )
+        ->assertSet( 'toggleOn', false );
+
+    Livewire::test( IncidentResponsePanel::class )
+        ->assertSet( 'available', false )
+        ->assertSet( 'toggleOn', false );
+} );
+
+it( 'reports an error when triage is called without an event id', function (): void {
+    Livewire::test( ThreatTriagePanel::class )
+        ->call( 'triage' )
+        ->assertSet( 'error', 'Select a security event to triage.' );
+} );
+
+it( 'populates the triage result when called with a valid event id', function (): void {
+    $event = SecurityEvent::create( [
+        'event_type' => SecurityEvent::TYPE_AUTHENTICATION,
+        'event_name' => 'login.failed',
+        'severity'   => SecurityEvent::SEVERITY_WARNING,
+        'ip_address' => '203.0.113.50',
+    ] );
+
+    Livewire::test( ThreatTriagePanel::class, [ 'eventId' => $event->id ] )
+        ->call( 'triage' )
+        ->assertSet( 'error', null )
+        ->assertSet( 'result.severity', fn ( $severity ) => in_array( $severity, [ 'info', 'low', 'medium', 'high', 'critical' ], true ) );
+} );
+
+it( 'rejects an out-of-range anomaly summary window', function (): void {
+    Livewire::test( AnomalySummaryPanel::class )
+        ->set( 'windowHours', 0 )
+        ->call( 'generate' )
+        ->assertSet( 'error', 'Window must be between 1 and 720 hours.' );
+
+    Livewire::test( AnomalySummaryPanel::class )
+        ->set( 'windowHours', 1000 )
+        ->call( 'generate' )
+        ->assertSet( 'error', 'Window must be between 1 and 720 hours.' );
+} );
+
+it( 'populates the anomaly summary result on generate', function (): void {
+    Livewire::test( AnomalySummaryPanel::class )
+        ->set( 'windowHours', 24 )
+        ->call( 'generate' )
+        ->assertSet( 'error', null )
+        ->assertSet( 'result.headline', fn ( $headline ) => is_string( $headline ) && '' !== $headline );
+} );
+
+it( 'reports an error when suggest is called without an incident id', function (): void {
+    Livewire::test( IncidentResponsePanel::class )
+        ->call( 'suggest' )
+        ->assertSet( 'error', 'Select an incident to advise on.' );
+} );
+
+it( 'populates the incident response result on suggest', function (): void {
+    $incident = SecurityIncident::factory()->create();
+
+    Livewire::test( IncidentResponsePanel::class, [ 'incidentId' => $incident->id ] )
+        ->call( 'suggest' )
+        ->assertSet( 'error', null )
+        ->assertSet( 'result.suggested_next_actions', fn ( $actions ) => is_array( $actions ) );
+} );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace Tests;
 
+use ArtisanPackUI\Ai\AiServiceProvider;
 use ArtisanPackUI\SecurityAnalytics\SecurityAnalyticsServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -39,6 +40,7 @@ abstract class TestCase extends BaseTestCase
         return [
             LivewireServiceProvider::class,
             SecurityAnalyticsServiceProvider::class,
+            AiServiceProvider::class,
         ];
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use ArtisanPackUI\Ai\AiServiceProvider;
 use ArtisanPackUI\SecurityAnalytics\SecurityAnalyticsServiceProvider;
+use Laravel\Ai\AiServiceProvider as LaravelAiServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -39,6 +40,7 @@ abstract class TestCase extends BaseTestCase
     {
         return [
             LivewireServiceProvider::class,
+            LaravelAiServiceProvider::class,
             SecurityAnalyticsServiceProvider::class,
             AiServiceProvider::class,
         ];


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.1.0
- **Release Date:** 2026-07-07
- **Release Type:** Minor (new features + PHP floor bump)
- **Release Branch:** `release/1.1`
- **Target Branch:** `main`

## Release Summary

Ships the three AI-assisted security features tracked on the v1.1 milestone. Each is opt-in, advisory-only (nothing triggers automatically), and short-circuits cleanly when the feature is toggled off or credentials aren't configured — no LLM cost is incurred in those cases.

Alongside the AI work this release hardens the surface against multi-tenant credential leaks (Livewire `#[Locked]` target IDs, provider cache invalidation, redacted exception messages) and lifts the PHP floor from 8.2 to 8.3 to align with the transitive `laravel/ai` requirement.

## Changelog

### Added

- Three AI-assisted features registered via `artisanpack-ui/ai`:
  - `security.threat_triage` — `ThreatTriageAgent` + `ThreatTriagePanel` (default model `claude-sonnet-4-6`). Plain-language severity and recommended actions for a `SecurityEvent`. Closes #20.
  - `security.anomaly_summary` — `AnomalySummaryAgent` + `AnomalySummaryPanel` (default model `claude-haiku-4-5-20251001`). Periodic digest of unusual events over a configurable 1–720 hour window. Closes #21.
  - `security.incident_response` — `IncidentResponseAgent` + `IncidentResponsePanel` (default model `claude-opus-4-7`). Advisory-only next-step suggestions for open incidents. Closes #22.
- Service-provider `aiFeatures()` auto-discovered by `artisanpack-ui/ai`'s boot pass; no manual registration.
- `CallsLaravelAi` trait: `Promptable` + `HasStructuredOutput` wiring, cached-provider invalidation, single-key envelope unwrap.
- Layered prompt overrides via `artisanpack.ai.features.{key}.instructions` config (settings-store → config → class default).
- Three Blade views under `resources/views/livewire/{name}-panel.blade.php`, registered as `security-analytics.{name}-panel` Livewire tags. Override via `resources/views/vendor/security-analytics/livewire/*.blade.php`.
- New `docs/usage/ai-features.md`.

### Changed

- **PHP floor: 8.2 → 8.3** (transitive requirement from `artisanpack-ui/ai` via `laravel/ai`).
- `composer.json` requires `artisanpack-ui/ai ^1.0.0-alpha.1` and declares a dev-only path repo against `../ai` (CI strips it, same pattern as `artisanpack-ui/visual-editor`).
- CI test matrix drops PHP 8.2 rows; retains PHP 8.3 / 8.4 × Laravel 12 / 13 × Livewire 3.6 / 4.0.
- Guzzle 7.11.1 → 7.13.2, PSR-7 2.11.0 → 2.12.3 (clears CVE-2026-55766 + two related medium advisories).

### Security

- Livewire panel target IDs (`$eventId`, `$incidentId`) marked `#[Locked]` — prevents client rewiring via wire protocol under the coarse `view-security-events` capability.
- `CallsLaravelAi::configureProvider()` invalidates `laravel/ai`'s `MultipleInstanceManager` cache after mutating credentials — fixes a cross-tenant credential leak where the first key seen by the process was silently reused for every subsequent agent call.
- Livewire panel `Throwable` catches now log server-side and surface a generic message — Guzzle/Anthropic exception messages could otherwise leak the upstream URL or API-key headers into the browser DOM.
- `ThreatTriageAgent::fetchRelated()` returns `[]` for events without correlation keys — prevents an empty closure-`where` from surfacing 10 arbitrary recent events (with PII) into the LLM prompt.

### Fixed

- Cache fingerprints hash content instead of proxies: incident hashes timeline contents (not `count($timeline)`); anomaly digest hashes per-anomaly (id, severity, detector) tuples.
- `hash('sha256', json_encode(...))` uses `JSON_INVALID_UTF8_SUBSTITUTE` and handles `false` returns so invalid UTF-8 in `SecurityEvent::details` no longer crashes the pipeline.
- `AnomalySummaryAgent::buildStatistics()` aggregates in the DB via `selectRaw` + `groupBy` (was hydrating every row into memory).
- `AnomalySummaryAgent::payload()` `is_array` guard on `$input['anomalies']` / `$input['statistics']` — throws documented `InvalidArgumentException` instead of raw `TypeError`.
- `AnomalySummaryAgent::$stream` set to `false` — matches the non-streaming reality of `execute()`.
- `unwrapStructured()` outer-key guard removed; correctly handles Opus double-wraps.
- `outputSchema()` derived from `schema()` on the trait — single source of truth.
- `aiFeatures()` labels/descriptions and `abort(403)` messages wrapped in `__()`; panel `render()` methods gained explicit `: View` return type.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #20 (ThreatTriageAgent)
- Closes #21 (AnomalySummaryAgent)
- Closes #22 (IncidentResponseAgent)

**Related PRs:**
- #23 — feat: three AI-assisted security features (merged to release/1.1)

## Breaking Changes

- [ ] No breaking changes
- [x] Breaking changes documented below

**Breaking changes:**

- **Minimum PHP requirement bumped from 8.2 to 8.3.** Consumers on PHP 8.2 will not receive 1.1.x releases via `~1.0` constraints. Package requires PHP 8.3+ transitively via `artisanpack-ui/ai → laravel/ai`.

**Migration guide:**

1. Ensure hosts run PHP 8.3+ before upgrading.
2. No code changes required — the three AI features are opt-in: install `artisanpack-ui/ai`, configure credentials via `artisanpack-ui/ai`'s standard env vars, and drop the Livewire panels into your views. Existing dashboards, logging, anomaly detection, alerting, SIEM export, and incident-response surfaces are unchanged.

## Testing Checklist

- [x] All automated tests passing (247 tests / 588 assertions)
- [x] Manual testing completed (real Anthropic call verified end-to-end from dev app, including layered prompt override)
- [x] Accessibility tests passing (panels use native `<button>` / `<input>`, auto-escaped `{{ }}` output, standard focus states)
- [x] Performance tests (none required — DB aggregation replaces in-memory groupBy)
- [x] Security scan completed (composer audit — no advisories)
- [ ] Tested in staging environment (n/a for library packages)
- [ ] Database migrations tested (n/a — no new migrations in 1.1)

**Testing notes:**

- Verified `configureProvider` cache-invalidation empirically in tinker
- Verified `artisanpack.ai.features.security.threat_triage.instructions` config override reaches the LLM (dev app tinker included a "must say BANANA" override; response contained BANANA)
- All CI matrix rows green (Lint + 8 test rows)

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated (AI features section, requirements bump)
- [x] API documentation updated (AI agents subsystem, `AgentUsageRecorded` event)
- [x] Migration guide written (see Breaking Changes above)
- [x] Release notes written (this PR body)
- [ ] Wiki updated (n/a — docs live in the repo)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json: 1.0.1 → 1.1.0)
- [ ] Git tag prepared: `v1.1.0` (post-merge)
- [x] Release branch created/updated: `release/1.1`
- [x] Dependencies updated and tested (Guzzle + PSR-7 patched for CVE-2026-55766)
- [ ] Build artifacts generated (n/a for Composer package)
- [ ] Deployment plan reviewed
- [ ] Rollback plan prepared
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR into `main`
2. Tag `v1.1.0` on the merge commit
3. Push the tag — the release workflow (`.github/workflows/release.yml`) will run tests and create the GitHub release

**Rollback plan:**
1. Consumers can pin to `^1.0` — they'll continue receiving 1.0.x if further 1.0 patches are cut
2. If a critical bug lands post-release, hotfix branch off the tag → merge to `main` → release `1.1.1`

### Configuration changes

- None required for existing consumers
- New optional keys under `artisanpack.ai.features.security.{threat_triage,anomaly_summary,incident_response}` for prompt/model overrides — see `docs/usage/ai-features.md`

### Environment variables

- None required for existing consumers
- New optional: `artisanpack-ui/ai`'s standard `ARTISANPACK_AI_*` vars (API key, provider, default model) — see `artisanpack-ui/ai` docs

## Post-Release Tasks

- [ ] Tag created: `v1.1.0`
- [ ] Release notes published (GitHub release)
- [ ] Documentation deployed (repo docs are the source of truth)
- [ ] Announcement sent
- [ ] Monitoring verified (no new telemetry surfaces in this release)
- [ ] Previous version support documented (1.0.x remains supported for security patches)

## Notes

- The `../ai` dev-only path repository in `composer.json` is stripped by CI (`.github/workflows/ci.yml` + `release.yml`) before install. Downstream `composer install` resolves `artisanpack-ui/ai` from Packagist normally.
- Blade views ship as plain Tailwind by design — override under `resources/views/vendor/security-analytics/livewire/*.blade.php` if you prefer richer components.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)